### PR TITLE
Shortcut expansion still used in non-shortcut associations

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -708,7 +708,9 @@ public class CDAModelUtil {
 		}
 
 		// TODO: what I should really do is test for an *implied* ActRelationship or Participation association
-		if (endType != null && getCDAClass(endType) != null && !(isInlineClass(endType))) {
+		if (endType != null && getCDAClass(endType) != null && !(isInlineClass(endType))
+		/* && !getCDAClass(property.getClass_()).getName().startsWith("Entry") */&&
+				!isInlineClass(property.getClass_())) {
 			message.append(markup
 					? "\n<li>"
 					: " ");


### PR DESCRIPTION
When a shortcut is used to link a Clinical Statement directly to a Section, MDHT generates the following, which is reasonably okay:

```
7. contains zero or more [0..*] entry, where its type is Adverse Reaction
  1. Contains exactly one [1..1] Adverse Reaction
```

You can read this as the section having one or more entry, with each entry having one Adverse Reaction (which is an act, thus the Clinical Statement).
When the model is fully expanded, so a Section > Entry > Clinical Statement, MDHT doesn't realise this and still adds the Clinical Statement to an Entry even though it has been explicitly stated:

```
6. MAY contain zero or more [0..*] entry
  1. Such entries contain exactly one [1..1] act, where its type is Adverse Reaction
    1. Contains exactly one [1..1] Adverse Reaction
```

The `1. Contains exactly one [1..1] Adverse Reaction` statement is redundant and should not be generated.
