### PR TITLE
Doclint is disabled

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.cda.xml.ui/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.cda.xml.ui/pom.xml
@@ -30,16 +30,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.cda.xml.ui/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.cda.xml.ui/pom.xml
@@ -30,13 +30,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ant/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ant/pom.xml
@@ -30,16 +30,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>						
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ant/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ant/pom.xml
@@ -30,13 +30,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>						
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/pom.xml
@@ -30,16 +30,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/pom.xml
@@ -30,13 +30,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/pom.xml
@@ -29,13 +29,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>						
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/pom.xml
@@ -29,16 +29,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>						
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.resources/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.resources/pom.xml
@@ -29,16 +29,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.resources/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.resources/pom.xml
@@ -29,13 +29,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.transform/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.transform/pom.xml
@@ -29,16 +29,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.transform/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.transform/pom.xml
@@ -29,13 +29,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui.dev/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui.dev/pom.xml
@@ -30,16 +30,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui.dev/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui.dev/pom.xml
@@ -30,13 +30,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/pom.xml
@@ -30,16 +30,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/pom.xml
@@ -30,13 +30,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.validation/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.validation/pom.xml
@@ -30,13 +30,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.validation/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.validation/pom.xml
@@ -30,15 +30,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
+							<additionalparam>${javadoc.opts}</additionalparam>
 						</configuration>
 					</execution>
 				</executions>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda/pom.xml
@@ -32,13 +32,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda/pom.xml
@@ -32,16 +32,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.hl7.datatypes/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.hl7.datatypes/pom.xml
@@ -30,16 +30,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.hl7.datatypes/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.hl7.datatypes/pom.xml
@@ -30,13 +30,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.hl7.rim/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.hl7.rim/pom.xml
@@ -30,16 +30,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.hl7.rim/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.hl7.rim/pom.xml
@@ -30,13 +30,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.hl7.vocab/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.hl7.vocab/pom.xml
@@ -30,16 +30,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.hl7.vocab/pom.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.hl7.vocab/pom.xml
@@ -30,13 +30,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/cda/plugins/pom.xml
+++ b/cda/plugins/pom.xml
@@ -33,6 +33,18 @@
 			<url>http://54.187.96.27:8081/nexus/content/repositories/snapshots</url>
 		</snapshotRepository>
 	</distributionManagement>
+	
+	<profiles>
+		<profile>
+			<id>doclint-java8-disable</id>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<properties>
+				<javadoc.opts>-Xdoclint:none</javadoc.opts>
+			</properties>
+		</profile>
+	</profiles>
 
 	<modules>
 		<module>org.openhealthtools.mdht.uml.hl7.vocab</module>

--- a/core/plugins/org.dita.dost/pom.xml
+++ b/core/plugins/org.dita.dost/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.dita.dost/pom.xml
+++ b/core/plugins/org.dita.dost/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.emf.runtime/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.emf.runtime/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.emf.runtime/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.emf.runtime/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.transform.core/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.transform.core/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.transform.core/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.transform.core/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.common.ui/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.common.ui/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.common.ui/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.common.ui/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.common/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.common/pom.xml
@@ -17,8 +17,23 @@
 			<version>17.0</version>
 		</dependency>
 	</dependencies>
+  
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.9.1</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<configuration>
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
@@ -29,23 +44,6 @@
 						<goals>
 							<goal>jar</goal>
 						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.common/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.common/pom.xml
@@ -36,13 +36,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.edit/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.edit/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.edit/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.edit/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.term.transform/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.term.transform/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.term.transform/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.term.transform/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.term.ui/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.term.ui/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.term.ui/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.term.ui/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.transform.ui/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.transform.ui/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.transform.ui/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.transform.ui/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.transform/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.transform/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.transform/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.transform/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.dev/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.dev/pom.xml
@@ -30,16 +30,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.dev/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.dev/pom.xml
@@ -30,13 +30,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.ide/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.ide/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.ide/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.ide/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.navigator/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.navigator/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.navigator/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.navigator/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.properties/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.properties/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.properties/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.properties/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.ui/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.ui/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.validation/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.validation/pom.xml
@@ -28,13 +28,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${org.apache.maven.version}</version>
+				<version>2.9</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>							
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/org.openhealthtools.mdht.uml.validation/pom.xml
+++ b/core/plugins/org.openhealthtools.mdht.uml.validation/pom.xml
@@ -28,16 +28,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>							
+							<additionalparam>${javadoc.opts}</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/core/plugins/pom.xml
+++ b/core/plugins/pom.xml
@@ -33,6 +33,17 @@
 		</snapshotRepository>
 	</distributionManagement>
 
+	<profiles>
+		<profile>
+			<id>doclint-java8-disable</id>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<properties>
+				<javadoc.opts>-Xdoclint:none</javadoc.opts>
+			</properties>
+		</profile>
+	</profiles>
 
 	<modules>
 		<module>org.dita.dost</module>


### PR DESCRIPTION
As mentioned here:
http://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete

JDK 8 comes with a new Doclint feature, which needs to be disabled.
