### PR TITLE
Mvn change to use one root

### DIFF
--- a/cda/features/pom.xml
+++ b/cda/features/pom.xml
@@ -14,26 +14,12 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>kepler</id>
-			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/kepler</url>
-		</repository>
-	</repositories>
-	
-	<distributionManagement>
-		<repository>
-			<id>remote.nexus</id>
-			<name>mdht-releases</name>
-			<url>http://54.187.96.27:8081/nexus/content/repositories/releases</url>
-		</repository>
-		<snapshotRepository>
-			<id>remote.nexus</id>
-			<name>mdht-snapshots</name>
-			<url>http://54.187.96.27:8081/nexus/content/repositories/snapshots</url>
-		</snapshotRepository>
-	</distributionManagement>
+	<parent>
+		<groupId>org.openhealthtools.mdht</groupId>
+		<artifactId>root</artifactId>
+		<version>${build_version}</version>
+		<relativePath>../../</relativePath>
+	</parent>
 
 	<modules>
 		<module>org.openhealthtools.mdht.uml.cda.basic-feature</module>

--- a/cda/features/pom.xml
+++ b/cda/features/pom.xml
@@ -8,12 +8,6 @@
 	<version>2.5.4-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
-	<properties>
-		<tycho-version>0.19.0</tycho-version>
-		<org.apache.maven.version>2.4</org.apache.maven.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
-
 	<parent>
 		<groupId>org.openhealthtools.mdht</groupId>
 		<artifactId>root</artifactId>

--- a/cda/plugins/pom.xml
+++ b/cda/plugins/pom.xml
@@ -8,11 +8,6 @@
 	<version>2.5.4-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
-	<properties>
-		<tycho-version>0.19.0</tycho-version>
-		<org.apache.maven.version>2.4</org.apache.maven.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
 	<parent>
 		<groupId>org.openhealthtools.mdht</groupId>
 		<artifactId>root</artifactId>

--- a/cda/plugins/pom.xml
+++ b/cda/plugins/pom.xml
@@ -13,26 +13,12 @@
 		<org.apache.maven.version>2.4</org.apache.maven.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
-	<repositories>
-		<repository>
-			<id>kepler</id>
-			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/kepler</url>
-		</repository>
-	</repositories>
-
-	<distributionManagement>
-		<repository>
-			<id>remote.nexus</id>
-			<name>mdht-releases</name>
-			<url>http://54.187.96.27:8081/nexus/content/repositories/releases</url>
-		</repository>
-		<snapshotRepository>
-			<id>remote.nexus</id>
-			<name>mdht-snapshots</name>
-			<url>http://54.187.96.27:8081/nexus/content/repositories/snapshots</url>
-		</snapshotRepository>
-	</distributionManagement>
+	<parent>
+		<groupId>org.openhealthtools.mdht</groupId>
+		<artifactId>root</artifactId>
+		<version>${build_version}</version>
+		<relativePath>../../</relativePath>
+	</parent>
 
 	<modules>
 		<module>org.openhealthtools.mdht.uml.hl7.vocab</module>

--- a/core/features/pom.xml
+++ b/core/features/pom.xml
@@ -12,25 +12,12 @@
 		<org.apache.maven.version>2.4</org.apache.maven.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
-	<repositories>
-		<repository>
-			<id>kepler</id>
-			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/kepler</url>
-		</repository>
-	</repositories>
-	<distributionManagement>
-		<repository>
-			<id>remote.nexus</id>
-			<name>mdht-releases</name>
-			<url>http://54.187.96.27:8081/nexus/content/repositories/releases</url>
-		</repository>
-		<snapshotRepository>
-			<id>remote.nexus</id>
-			<name>mdht-snapshots</name>
-			<url>http://54.187.96.27:8081/nexus/content/repositories/snapshots</url>
-		</snapshotRepository>
-	</distributionManagement>
+	<parent>
+		<groupId>org.openhealthtools.mdht</groupId>
+		<artifactId>root</artifactId>
+		<version>${build_version}</version>
+		<relativePath>../../</relativePath>
+	</parent>
 	<modules>
 		<module>org.dita.dost-feature</module>
 		<module>org.openhealthtools.mdht-feature</module>

--- a/core/features/pom.xml
+++ b/core/features/pom.xml
@@ -7,11 +7,7 @@
 	<artifactId>features</artifactId>
 	<version>2.5.4-SNAPSHOT</version>
 	<packaging>pom</packaging>
-	<properties>
-		<tycho-version>0.19.0</tycho-version>
-		<org.apache.maven.version>2.4</org.apache.maven.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
+	
 	<parent>
 		<groupId>org.openhealthtools.mdht</groupId>
 		<artifactId>root</artifactId>

--- a/core/plugins/pom.xml
+++ b/core/plugins/pom.xml
@@ -6,33 +6,19 @@
 	<artifactId>core</artifactId>
 	<version>2.5.4-SNAPSHOT</version>
 	<packaging>pom</packaging>
+	
+	<parent>
+		<groupId>org.openhealthtools.mdht</groupId>
+		<artifactId>root</artifactId>
+		<version>${build_version}</version>
+		<relativePath>../../</relativePath>
+	</parent>
 
 	<properties>
 		<tycho-version>0.19.0</tycho-version>
 		<org.apache.maven.version>2.4</org.apache.maven.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
-	<repositories>
-		<repository>
-			<id>kepler</id>
-			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/kepler</url>
-		</repository>
-	</repositories>
-
-	<distributionManagement>
-		<repository>
-			<id>remote.nexus</id>
-			<name>mdht-releases</name>
-			<url>http://54.187.96.27:8081/nexus/content/repositories/releases</url>
-		</repository>
-		<snapshotRepository>
-			<id>remote.nexus</id>
-			<name>mdht-snapshots</name>
-			<url>http://54.187.96.27:8081/nexus/content/repositories/snapshots</url>
-		</snapshotRepository>
-	</distributionManagement>
-
 
 	<modules>
 		<module>org.dita.dost</module>
@@ -137,14 +123,5 @@
 
 		</plugins>
 	</build>
-
-	<scm>
-		<connection>scm:git:git@github.com:mdht/mdht.git</connection>
-		<url>scm:git:git@github.com:mdht/mdht.git</url>
-		<developerConnection>scm:git:git@github.com:mdht/mdht.git</developerConnection>
-		<tag>HEAD</tag>
-	</scm>
-
-
 
 </project>

--- a/core/plugins/pom.xml
+++ b/core/plugins/pom.xml
@@ -13,13 +13,7 @@
 		<version>${build_version}</version>
 		<relativePath>../../</relativePath>
 	</parent>
-
-	<properties>
-		<tycho-version>0.19.0</tycho-version>
-		<org.apache.maven.version>2.4</org.apache.maven.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
-
+	
 	<modules>
 		<module>org.dita.dost</module>
 		<module>org.openhealthtools.mdht.emf.runtime</module>

--- a/pom.xml
+++ b/pom.xml
@@ -4,20 +4,49 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openhealthtools.mdht</groupId>
 	<artifactId>root</artifactId>
-	<version>2.5.4-SNAPSHOT</version>
+	<version>${build_version}</version>
 	<packaging>pom</packaging>
 
 	<properties>
-		<build_version>2.5.2-SNAPSHOT</build_version>
+		<build_version>2.5.4-SNAPSHOT</build_version>
 		<tycho-version>0.19.0</tycho-version>
+		<release_url>http://54.187.96.27:8081/nexus/content/repositories/releases</release_url>
+		<snapshot_url>http://54.187.96.27:8081/nexus/content/repositories/snapshots</snapshot_url>
+		<site_url>http://54.187.96.27:8081/nexus/content/repositories/snapshots</site_url>
 	</properties>
+	
+	<repositories>
+		<repository>
+			<id>kepler</id>
+			<layout>p2</layout>
+			<url>http://download.eclipse.org/releases/kepler</url>
+		</repository>
+	</repositories>
 
+	<distributionManagement>
+		<repository>
+			<id>remote.nexus</id>
+			<name>mdht-releases</name>
+			<url>${release_url}</url>
+		</repository>
+		<snapshotRepository>
+			<id>remote.nexus</id>
+			<name>mdht-snapshots</name>
+			<url>${snapshot_url}</url>
+		</snapshotRepository>
+		<site>
+			<id>remote.nexus</id>
+			<name>mdht-site</name>
+			<url>${site_url}</url>
+		</site>
+	</distributionManagement>
+	
 	<modules>
 		<module>core/plugins</module>
 		<module>core/features</module>
 		<module>cda/plugins</module>
 		<module>cda/features</module>
-		<module>releng/sites</module>
+		
 	</modules>
 	<profiles>
 		<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
 
 	<properties>
 		<build_version>2.5.4-SNAPSHOT</build_version>
-		<tycho-version>0.19.0</tycho-version>
+		<tycho-version>0.22.0</tycho-version>
 		<org.apache.maven.version>2.4</org.apache.maven.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<release_url>http://54.187.96.27:8081/nexus/content/repositories/releases</release_url>
 		<snapshot_url>http://54.187.96.27:8081/nexus/content/repositories/snapshots</snapshot_url>
-		<site_url>http://54.187.96.27:8081/nexus/content/repositories/snapshots</site_url>
+		<repository_id>remote.nexus</repository_id>
 	</properties>
 	
 	<repositories>
@@ -27,12 +27,12 @@
 
 	<distributionManagement>
 		<repository>
-			<id>remote.nexus</id>
+			<id>${repository_id}</id>
 			<name>mdht-releases</name>
 			<url>${release_url}</url>
 		</repository>
 		<snapshotRepository>
-			<id>remote.nexus</id>
+			<id>${repository_id}</id>
 			<name>mdht-snapshots</name>
 			<url>${snapshot_url}</url>
 		</snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,8 @@
 	<properties>
 		<build_version>2.5.4-SNAPSHOT</build_version>
 		<tycho-version>0.19.0</tycho-version>
+		<org.apache.maven.version>2.4</org.apache.maven.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<release_url>http://54.187.96.27:8081/nexus/content/repositories/releases</release_url>
 		<snapshot_url>http://54.187.96.27:8081/nexus/content/repositories/snapshots</snapshot_url>
 		<site_url>http://54.187.96.27:8081/nexus/content/repositories/snapshots</site_url>
@@ -34,11 +36,6 @@
 			<name>mdht-snapshots</name>
 			<url>${snapshot_url}</url>
 		</snapshotRepository>
-		<site>
-			<id>remote.nexus</id>
-			<name>mdht-site</name>
-			<url>${site_url}</url>
-		</site>
 	</distributionManagement>
 	
 	<modules>
@@ -46,7 +43,7 @@
 		<module>core/features</module>
 		<module>cda/plugins</module>
 		<module>cda/features</module>
-		
+		<module>releng/sites</module>
 	</modules>
 	<profiles>
 		<profile>

--- a/releng/sites/pom.xml
+++ b/releng/sites/pom.xml
@@ -8,12 +8,6 @@
 	<version>2.5.4-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
-	<properties>
-		<tycho-version>0.19.0</tycho-version>
-		<org.apache.maven.version>2.4</org.apache.maven.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
-
 	<parent>
 		<groupId>org.openhealthtools.mdht</groupId>
 		<artifactId>root</artifactId>

--- a/releng/sites/pom.xml
+++ b/releng/sites/pom.xml
@@ -14,29 +14,12 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>kepler</id>
-			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/kepler</url>
-		</repository>
-
-
-	</repositories>
-	
-	<distributionManagement>
-		<repository>
-			<id>remote.nexus</id>
-			<name>mdht-releases</name>
-			<url>http://54.187.96.27:8081/nexus/content/repositories/releases</url>
-		</repository>
-		<snapshotRepository>
-			<id>remote.nexus</id>
-			<name>mdht-snapshots</name>
-			<url>http://54.187.96.27:8081/nexus/content/repositories/snapshots</url>
-		</snapshotRepository>
-	</distributionManagement>
-	
+	<parent>
+		<groupId>org.openhealthtools.mdht</groupId>
+		<artifactId>root</artifactId>
+		<version>${build_version}</version>
+		<relativePath>../../</relativePath>
+	</parent>
 
 	<modules>
 		<module>cda.design.site</module>


### PR DESCRIPTION
Previously root pom file was not configured as parent pom file. This PR combines all the properties and deploy settings in the root pom file so that it's a lot easier to deploy. Also Tycho version was updated.
