### PR TITLE
Removing unnecessary parentheses for ruleID

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -402,8 +402,9 @@ public class CDAModelUtil {
 		templateConstraint = templateConstraint.replaceAll("%templateId%", (templateId != null
 				? templateId
 				: ""));
-		templateConstraint = templateConstraint.replaceAll("%ruleId%", (ruleIds != null
-				? ruleIds
+		templateConstraint = templateConstraint.replaceAll("\\( %ruleId% \\) ", (ruleIds != null &&
+				!ruleIds.trim().isEmpty()
+				? "( " + ruleIds + " ) "
 				: ""));
 
 		templateConstraint = templateConstraint.replaceAll("%templateVersion%", (templateVersion != null


### PR DESCRIPTION
If there are no rule ids, conformance rule still shows parentheses. This fixes that issue and removes parentheses. For example:
contain exactly one [1..1] templateId ( ) such that

After this patch it becomes:
contain exactly one [1..1] templateId such that
