### PR TITLE
Don't pluralize if name ends with number

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/NameUtilities.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/NameUtilities.java
@@ -55,7 +55,8 @@ public class NameUtilities
     public static String pluralize(String name) {
         
         // first check for already in plural form
-        if (name.endsWith("List") || (name.endsWith("s") && !name.endsWith("ss"))) {
+        if (name.endsWith("List") || (name.endsWith("s") && !name.endsWith("ss") || 
+        		Character.isDigit(name.charAt(name.length() - 1)))) {
             return name;
         }
             


### PR DESCRIPTION
Previously it was pluralizing the name that was ending with a number (such as coverage2 to coverage2s ). This PR fixes that issue.
