### PR TITLE
Fixed <code> entry being overwritten

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/InstanceGenerator.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/InstanceGenerator.java
@@ -457,7 +457,9 @@ public class InstanceGenerator {
 									datatypesInit.setCurrentFeature(structuralFeature);
 									datatypesInit.doSwitch(objectToSet);
 								}
-								eObject.eSet(structuralFeature, objectToSet);
+								if (!(structuralFeature.getEType().getName() + structuralFeature.getName()).equals("CDcode")) {
+									eObject.eSet(structuralFeature, objectToSet);
+								}
 							} catch (Exception cce) {
 								System.out.println("Unable to set " + eClass.getName() + "." +
 										structuralFeature.getEType().getName() + structuralFeature.getName());


### PR DESCRIPTION
There is a <code> entry that is automatically generated, it also overwrites existing code attributes in the XML sample. This PR prevents auto generated <code> entry to be used in the XML example so that it doesn't overwrite.
