### PR TITLE
Some templates aren't in the XML Sample

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/InstanceGenerator.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/InstanceGenerator.java
@@ -316,6 +316,9 @@ public class InstanceGenerator {
 						Property cdaProperty = null;
 						if (cdaSourceClass != null) {
 							cdaProperty = cdaSourceClass.getAttribute(null, cdaTypeClass);
+							cdaProperty = cdaProperty == null
+									? cdaSourceClass.getAttribute(cdaTypeClass.getName(), null, true, null)
+									: cdaProperty;
 						}
 
 						if (cdaProperty != null) {


### PR DESCRIPTION
Some templates aren't in the XML Sample, this is due to their cdaTypeClass having a same type of class in a different instance than the found attribute of the source class.
This fix adds another call which uses only typeclass's name.
