### PR TITLE
Code highlighting is added for XML examples

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/TransformClassContent.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/TransformClassContent.java
@@ -430,7 +430,7 @@ public class TransformClassContent extends TransformAbstract {
 	}
 
 	private void appendExample(PrintWriter writer, Class umlClass) {
-		writer.print("<codeblock id=\"example\"><![CDATA[");
+		writer.print("<codeblock id=\"example\" outputclass=\"language-xml\"><![CDATA[");
 
 		if (instanceGenerator != null) {
 


### PR DESCRIPTION
Where MDHT does <codeblock id="example>, it needs to do <codeblock id="example" outputclass="language-xml"> to tell DITA processors to highlight the XML examples.
