### PR TITLE
Fix for templateId

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAConstraints.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAConstraints.java
@@ -4,10 +4,10 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *     Sean Muir (JKM Software)  - initial implementation
- *     
+ *
  *******************************************************************************/
 package org.openhealthtools.mdht.uml.cda.core.util;
 
@@ -23,6 +23,14 @@ public class CDAConstraints extends NLS {
 	public static String CDAVersionTemplateIdConstraint;
 
 	public static String CDAVersionTemplateIdConstraintMarkup;
+
+	public static String CDATemplateIdConstraintDiffMultip;
+
+	public static String CDATemplateIdConstraintMarkupDiffMultip;
+
+	public static String CDAVersionTemplateIdConstraintDiffMultip;
+
+	public static String CDAVersionTemplateIdConstraintMarkupDiffMultip;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, CDAConstraints.class);

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAConstraints.properties
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAConstraints.properties
@@ -18,3 +18,10 @@ CDATemplateIdConstraintMarkup=<b>SHALL</b> contain exactly one [1..1] templateId
 
 CDAVersionTemplateIdConstraint=SHALL contain exactly one [1..1] templateId ( %ruleId% ) such that it SHALL contain exactly one [1..1] @root="%templateId%" and SHALL contain exactly one [1..1] @extension="%templateVersion%"
 CDAVersionTemplateIdConstraintMarkup=<b>SHALL</b> contain exactly one [1..1] templateId ( %ruleId% ) such that it <ol><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>="%templateId%"</li> <li>SHALL contain exactly one [1..1] <b>@extension</b>="%templateVersion%"</li> </ol>
+
+CDATemplateIdConstraintDiffMultip=SHALL contain exactly one templateId ( %ruleId% ) [1..1] such that it SHALL contain exactly one @root="%templateId%" [1..1]
+CDATemplateIdConstraintMarkupDiffMultip=<b>SHALL</b> contain exactly one templateId ( %ruleId% ) [1..1] such that it <ol><li><b>SHALL</b> contain exactly one <b>@root</b>="%templateId%" [1..1]</li></ol>
+
+
+CDAVersionTemplateIdConstraintDiffMultip=SHALL contain exactly one templateId ( %ruleId% ) [1..1] such that it SHALL contain exactly one @root="%templateId%" [1..1] and SHALL contain exactly one @extension="%templateVersion%" [1..1]
+CDAVersionTemplateIdConstraintMarkupDiffMultip=<b>SHALL</b> contain exactly one templateId ( %ruleId% ) [1..1] such that it <ol><li><b>SHALL</b> contain exactly one <b>@root</b>="%templateId%" [1..1]</li> <li>SHALL contain exactly one <b>@extension</b>="%templateVersion%" [1..1]</li> </ol>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -383,23 +383,40 @@ public class CDAModelUtil {
 		return (String) umlSwitch.doSwitch(element);
 	}
 
+	private static String getCDATemplateIdConstraint(boolean isTemplateVersionEmpty, boolean markup) {
+		String result = "";
+		if (isTemplateVersionEmpty) {
+			if (cardinalityAfterElement) {
+				result = markup
+						? CDAConstraints.CDATemplateIdConstraintMarkupDiffMultip
+						: CDAConstraints.CDATemplateIdConstraintDiffMultip;
+			} else {
+				result = markup
+						? CDAConstraints.CDATemplateIdConstraintMarkup
+						: CDAConstraints.CDATemplateIdConstraint;
+			}
+
+		} else {
+			if (cardinalityAfterElement) {
+				result = markup
+						? CDAConstraints.CDAVersionTemplateIdConstraintMarkupDiffMultip
+						: CDAConstraints.CDAVersionTemplateIdConstraintDiffMultip;
+			} else {
+				result = markup
+						? CDAConstraints.CDAVersionTemplateIdConstraintMarkup
+						: CDAConstraints.CDAVersionTemplateIdConstraint;
+			}
+		}
+
+		return result;
+	}
+
 	public static String computeConformanceMessage(Class template, boolean markup) {
 
 		String templateId = getTemplateId(template);
 		String templateVersion = getTemplateVersion(template);
 
-		String templateConstraint = "";
-
-		if (StringUtils.isEmpty(templateVersion)) {
-			templateConstraint = markup
-					? CDAConstraints.CDATemplateIdConstraintMarkup
-					: CDAConstraints.CDATemplateIdConstraint;
-
-		} else {
-			templateConstraint = markup
-					? CDAConstraints.CDAVersionTemplateIdConstraintMarkup
-					: CDAConstraints.CDAVersionTemplateIdConstraint;
-		}
+		String templateConstraint = getCDATemplateIdConstraint(StringUtils.isEmpty(templateVersion), markup);
 
 		String ruleIds = getConformanceRuleIds(template);
 		templateConstraint = templateConstraint.replaceAll("%templateId%", (templateId != null

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/plugin.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/plugin.xml
@@ -496,8 +496,17 @@
       <page id="org.openhealthtools.mdht.uml.cda.ui.editors.Page1"
          class="org.openhealthtools.mdht.uml.cda.ui.editors.MDHTPreferences"
          name="MDHT">
+         <keywordReference id="MDHTPreferences.multiplicity1" />
+         <keywordReference id="MDHTPreferences.multiplicity2" />
+         <keywordReference id="MDHTPreferences.multiplicity3" />
       </page>
    </extension>
+   
+   <extension point="org.eclipse.ui.keywords">
+      <keyword label="multiplicity" id="MDHTPreferences.multiplicity1" />
+      <keyword label="element" id="MDHTPreferences.multiplicity2" />
+      <keyword label="properties" id="MDHTPreferences.multiplicity3" />
+   </extension>    
    
    <extension
       point="org.eclipse.core.runtime.preferences">

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/editors/MDHTPreferences.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/editors/MDHTPreferences.java
@@ -26,10 +26,10 @@ import org.openhealthtools.mdht.uml.cda.ui.internal.Activator;
 
 public class MDHTPreferences extends PreferencePage implements IWorkbenchPreferencePage {
 
-	private static String CARDINALITY_CHECK_BOX_LABEL = "Show multiplicty after the element name"
+	private static String CARDINALITY_CHECK_BOX_LABEL = "Show multiplicity after the element name"
 			+ " in the Properties view";
 
-	private static String CARDINALITY_CHECK_BOX_TOOLTIP = "Show multiplicty after the element name in the"
+	private static String CARDINALITY_CHECK_BOX_TOOLTIP = "Show multiplicity after the element name in the"
 			+ " Properties view. This does not affect the DITA publication (PDF, Online) - "
 			+ "for that, dita-transform.xml needs to be adjusted to say "
 			+ "cardinalityAfterElement=\"true\" in <transformToDita>";

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/editors/MDHTPreferences.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/editors/MDHTPreferences.java
@@ -26,10 +26,10 @@ import org.openhealthtools.mdht.uml.cda.ui.internal.Activator;
 
 public class MDHTPreferences extends PreferencePage implements IWorkbenchPreferencePage {
 
-	private static String CARDINALITY_CHECK_BOX_LABEL = "Show cardinality after the element name"
+	private static String CARDINALITY_CHECK_BOX_LABEL = "Show multiplicty after the element name"
 			+ " in the Properties view";
 
-	private static String CARDINALITY_CHECK_BOX_TOOLTIP = "Show cardinality after the element name in the"
+	private static String CARDINALITY_CHECK_BOX_TOOLTIP = "Show multiplicty after the element name in the"
 			+ " Properties view. This does not affect the DITA publication (PDF, Online) - "
 			+ "for that, dita-transform.xml needs to be adjusted to say "
 			+ "cardinalityAfterElement=\"true\" in <transformToDita>";


### PR DESCRIPTION
In previous PR for cardinality after element ( https://github.com/mdht/mdht/pull/47 ) had an issue for not showing the difference for templateId so that issue is now fixed. It's a quick and dirty fix as something complex would make things more complicated when templateId strings are split.

Also some enhancements were added (such as keyword search, changing cardinality to multiplicity for UML etc.)
