### PR TITLE
templateId multiplicity not published consistently with the model

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/META-INF/MANIFEST.MF
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources;visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
-Export-Package: org.openhealthtools.mdht.uml.cda.core.internal.generat
- e,org.openhealthtools.mdht.uml.cda.core.profile,org.openhealthtools.m
- dht.uml.cda.core.profile.impl,org.openhealthtools.mdht.uml.cda.core.p
- rofile.util,org.openhealthtools.mdht.uml.cda.core.util
+Export-Package: org.openhealthtools.mdht.uml.cda.core.internal.generate,
+ org.openhealthtools.mdht.uml.cda.core.profile,
+ org.openhealthtools.mdht.uml.cda.core.profile.impl,
+ org.openhealthtools.mdht.uml.cda.core.profile.util,
+ org.openhealthtools.mdht.uml.cda.core.util

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/model/CDA.profile.genmodel
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/model/CDA.profile.genmodel
@@ -122,6 +122,7 @@
       <genFeatures xsi:type="genmodel:GenFeature" createChild="false" ecoreFeature="ecore:EAttribute profile.ecore#//CDATemplate/assigningAuthorityName"/>
       <genFeatures xsi:type="genmodel:GenFeature" createChild="false" ecoreFeature="ecore:EAttribute profile.ecore#//CDATemplate/contextDependent"/>
       <genFeatures xsi:type="genmodel:GenFeature" createChild="false" ecoreFeature="ecore:EAttribute profile.ecore#//CDATemplate/templateVersion"/>
+      <genFeatures xsi:type="genmodel:GenFeature" createChild="false" ecoreFeature="ecore:EAttribute profile.ecore#//CDATemplate/templateMultiplicity"/>
     </genClasses>
     <genClasses xsi:type="genmodel:GenClass" ecoreClass="profile.ecore#//ConstraintValidation">
       <genFeatures xsi:type="genmodel:GenFeature" notify="false" createChild="false"

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/model/profile.ecore
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/model/profile.ecore
@@ -118,6 +118,8 @@
         defaultValueLiteral="false"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="templateVersion" ordered="false"
         eType="ecore:EDataType platform:/plugin/org.eclipse.uml2.types/model/Types.ecore#//String"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="templateMultiplicity" ordered="false"
+        eType="ecore:EDataType platform:/plugin/org.eclipse.uml2.types/model/Types.ecore#//String"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ConstraintValidation" eSuperTypes="#//Validation">
     <eStructuralFeatures xsi:type="ecore:EReference" name="base_Constraint" ordered="false"

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/plugin.xml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/plugin.xml
@@ -33,4 +33,18 @@
             genModel="model/CDA.profile.genmodel"/>
    </extension>
 
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated CDA.profile -->
+      <package
+            uri="http://www.openhealthtools.org/mdht/schemas/cda/4"
+            class="org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage"
+            genModel="model/CDA.profile.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <!-- @generated CDA.profile -->
+      <parser
+            type="cda"
+            class="org.openhealthtools.mdht.uml.cda.core.profile.util.CDAResourceFactoryImpl"/>
+   </extension>
 </plugin>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/ActRelationship.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/ActRelationship.java
@@ -20,16 +20,16 @@ import org.eclipse.uml2.uml.EnumerationLiteral;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Act Relationship</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getBase_Association <em>Base Association</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getAssociationType <em>Association Type</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getTypeCode <em>Type Code</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getBase_Association <em>Base Association</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getAssociationType <em>Association Type</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getTypeCode <em>Type Code</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getActRelationship()
  * @model
  * @generated
@@ -42,7 +42,6 @@ public interface ActRelationship extends EObject {
 	 * If the meaning of the '<em>Association Type</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Association Type</em>' reference.
 	 * @see #setAssociationType(org.eclipse.uml2.uml.Class)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getActRelationship_AssociationType()
@@ -58,7 +57,6 @@ public interface ActRelationship extends EObject {
 	 * If the meaning of the '<em>Base Association</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Base Association</em>' reference.
 	 * @see #setBase_Association(Association)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getActRelationship_Base_Association()
@@ -74,7 +72,6 @@ public interface ActRelationship extends EObject {
 	 * If the meaning of the '<em>Type Code</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Type Code</em>' reference.
 	 * @see #setTypeCode(EnumerationLiteral)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getActRelationship_TypeCode()
@@ -84,26 +81,20 @@ public interface ActRelationship extends EObject {
 	EnumerationLiteral getTypeCode();
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getAssociationType <em>Association Type</em>}'
-	 * reference.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getAssociationType <em>Association Type</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Association Type</em>' reference.
+	 * @param value the new value of the '<em>Association Type</em>' reference.
 	 * @see #getAssociationType()
 	 * @generated
 	 */
 	void setAssociationType(org.eclipse.uml2.uml.Class value);
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getBase_Association <em>Base Association</em>}'
-	 * reference.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getBase_Association <em>Base Association</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Base Association</em>' reference.
+	 * @param value the new value of the '<em>Base Association</em>' reference.
 	 * @see #getBase_Association()
 	 * @generated
 	 */
@@ -113,9 +104,7 @@ public interface ActRelationship extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getTypeCode <em>Type Code</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Type Code</em>' reference.
+	 * @param value the new value of the '<em>Type Code</em>' reference.
 	 * @see #getTypeCode()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/AssociationValidation.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/AssociationValidation.java
@@ -18,14 +18,14 @@ import org.eclipse.uml2.uml.Association;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Association Validation</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation#getBase_Association <em>Base Association</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation#getBase_Association <em>Base Association</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getAssociationValidation()
  * @model
  * @generated
@@ -38,7 +38,6 @@ public interface AssociationValidation extends Validation {
 	 * If the meaning of the '<em>Base Association</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Base Association</em>' reference.
 	 * @see #setBase_Association(Association)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getAssociationValidation_Base_Association()
@@ -48,13 +47,10 @@ public interface AssociationValidation extends Validation {
 	Association getBase_Association();
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation#getBase_Association
-	 * <em>Base Association</em>}' reference.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation#getBase_Association <em>Base Association</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Base Association</em>' reference.
+	 * @param value the new value of the '<em>Base Association</em>' reference.
 	 * @see #getBase_Association()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/CDAFactory.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/CDAFactory.java
@@ -19,7 +19,6 @@ import org.eclipse.emf.ecore.EFactory;
  * The <b>Factory</b> for the model.
  * It provides a create method for each non-abstract class of the model.
  * <!-- end-user-doc -->
- * 
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage
  * @generated
  */
@@ -28,7 +27,6 @@ public interface CDAFactory extends EFactory {
 	 * The singleton instance of the factory.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	CDAFactory eINSTANCE = org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAFactoryImpl.init();
@@ -37,7 +35,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Act Relationship</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Act Relationship</em>'.
 	 * @generated
 	 */
@@ -47,7 +44,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Association Validation</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Association Validation</em>'.
 	 * @generated
 	 */
@@ -57,7 +53,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Template</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Template</em>'.
 	 * @generated
 	 */
@@ -67,7 +62,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Class Validation</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Class Validation</em>'.
 	 * @generated
 	 */
@@ -77,7 +71,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Codegen Support</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Codegen Support</em>'.
 	 * @generated
 	 */
@@ -87,7 +80,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Code System Constraint</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Code System Constraint</em>'.
 	 * @generated
 	 */
@@ -97,7 +89,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Concept Domain Constraint</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Concept Domain Constraint</em>'.
 	 * @generated
 	 */
@@ -107,7 +98,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Conforms To</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Conforms To</em>'.
 	 * @generated
 	 */
@@ -117,7 +107,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Constraint Validation</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Constraint Validation</em>'.
 	 * @generated
 	 */
@@ -127,7 +116,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Entry</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Entry</em>'.
 	 * @generated
 	 */
@@ -137,7 +125,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Entry Relationship</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Entry Relationship</em>'.
 	 * @generated
 	 */
@@ -147,7 +134,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Null Flavor</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Null Flavor</em>'.
 	 * @generated
 	 */
@@ -157,7 +143,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Participation</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Participation</em>'.
 	 * @generated
 	 */
@@ -167,7 +152,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Logical Constraint</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Logical Constraint</em>'.
 	 * @generated
 	 */
@@ -177,7 +161,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Inline</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Inline</em>'.
 	 * @generated
 	 */
@@ -187,7 +170,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Unimplementable</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Unimplementable</em>'.
 	 * @generated
 	 */
@@ -197,7 +179,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Property Validation</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Property Validation</em>'.
 	 * @generated
 	 */
@@ -207,7 +188,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Text Value</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Text Value</em>'.
 	 * @generated
 	 */
@@ -217,7 +197,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Value Set Constraint</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Value Set Constraint</em>'.
 	 * @generated
 	 */
@@ -227,7 +206,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns a new object of class '<em>Vocab Specification</em>'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return a new object of class '<em>Vocab Specification</em>'.
 	 * @generated
 	 */
@@ -237,7 +215,6 @@ public interface CDAFactory extends EFactory {
 	 * Returns the package supported by this factory.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the package supported by this factory.
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/CDAPackage.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/CDAPackage.java
@@ -42,7 +42,6 @@ import org.openhealthtools.mdht.uml.term.core.profile.TermPackage;
  * org.openhealthtools.mdht.uml.cda.validation.internal.properties.SeverityAndCardinalityConstraint
  * org.openhealthtools.mdht.uml.cda.validation.internal.properties.PropertyValidation
  * <!-- end-model-doc -->
- * 
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAFactory
  * @model kind="package"
  * @generated
@@ -58,7 +57,6 @@ public interface CDAPackage extends EPackage {
 	 * <li>and each data type</li>
 	 * </ul>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	interface Literals {
@@ -66,7 +64,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryImpl <em>Entry</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getEntry()
 		 * @generated
@@ -77,17 +74,14 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Type Code</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute ENTRY__TYPE_CODE = eINSTANCE.getEntry_TypeCode();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.AssociationValidationImpl
-		 * <em>Association Validation</em>}' class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.AssociationValidationImpl <em>Association Validation</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.AssociationValidationImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getAssociationValidation()
 		 * @generated
@@ -98,7 +92,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Base Association</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference ASSOCIATION_VALIDATION__BASE_ASSOCIATION = eINSTANCE.getAssociationValidation_Base_Association();
@@ -107,7 +100,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValidationImpl <em>Validation</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ValidationImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getValidation()
 		 * @generated
@@ -118,7 +110,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Message</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute VALIDATION__MESSAGE = eINSTANCE.getValidation_Message();
@@ -127,7 +118,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Severity</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute VALIDATION__SEVERITY = eINSTANCE.getValidation_Severity();
@@ -136,7 +126,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Rule Id</b></em>' attribute list feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute VALIDATION__RULE_ID = eINSTANCE.getValidation_RuleId();
@@ -145,17 +134,14 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Mandatory</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute VALIDATION__MANDATORY = eINSTANCE.getValidation_Mandatory();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryRelationshipImpl
-		 * <em>Entry Relationship</em>}' class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryRelationshipImpl <em>Entry Relationship</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryRelationshipImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getEntryRelationship()
 		 * @generated
@@ -166,17 +152,14 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Type Code</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute ENTRY_RELATIONSHIP__TYPE_CODE = eINSTANCE.getEntryRelationship_TypeCode();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl <em>Codegen Support</em>}'
-		 * class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl <em>Codegen Support</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getCodegenSupport()
 		 * @generated
@@ -187,7 +170,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Base Package</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute CODEGEN_SUPPORT__BASE_PACKAGE = eINSTANCE.getCodegenSupport_BasePackage();
@@ -196,7 +178,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Ns Prefix</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute CODEGEN_SUPPORT__NS_PREFIX = eINSTANCE.getCodegenSupport_NsPrefix();
@@ -205,7 +186,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Ns URI</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute CODEGEN_SUPPORT__NS_URI = eINSTANCE.getCodegenSupport_NsURI();
@@ -214,7 +194,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Package Name</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute CODEGEN_SUPPORT__PACKAGE_NAME = eINSTANCE.getCodegenSupport_PackageName();
@@ -223,7 +202,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Prefix</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute CODEGEN_SUPPORT__PREFIX = eINSTANCE.getCodegenSupport_Prefix();
@@ -232,17 +210,14 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Base Namespace</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference CODEGEN_SUPPORT__BASE_NAMESPACE = eINSTANCE.getCodegenSupport_Base_Namespace();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.PropertyValidationImpl
-		 * <em>Property Validation</em>}' class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.PropertyValidationImpl <em>Property Validation</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.PropertyValidationImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getPropertyValidation()
 		 * @generated
@@ -253,17 +228,14 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Base Property</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference PROPERTY_VALIDATION__BASE_PROPERTY = eINSTANCE.getPropertyValidation_Base_Property();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ClassValidationImpl <em>Class Validation</em>}'
-		 * class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ClassValidationImpl <em>Class Validation</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ClassValidationImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getClassValidation()
 		 * @generated
@@ -274,17 +246,14 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Base Class</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference CLASS_VALIDATION__BASE_CLASS = eINSTANCE.getClassValidation_Base_Class();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl
-		 * <em>Vocab Specification</em>}' class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl <em>Vocab Specification</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getVocabSpecification()
 		 * @generated
@@ -295,7 +264,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Code</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute VOCAB_SPECIFICATION__CODE = eINSTANCE.getVocabSpecification_Code();
@@ -304,7 +272,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Code System</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute VOCAB_SPECIFICATION__CODE_SYSTEM = eINSTANCE.getVocabSpecification_CodeSystem();
@@ -313,7 +280,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Code System Name</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute VOCAB_SPECIFICATION__CODE_SYSTEM_NAME = eINSTANCE.getVocabSpecification_CodeSystemName();
@@ -322,7 +288,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Code System Version</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute VOCAB_SPECIFICATION__CODE_SYSTEM_VERSION = eINSTANCE.getVocabSpecification_CodeSystemVersion();
@@ -331,7 +296,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Display Name</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute VOCAB_SPECIFICATION__DISPLAY_NAME = eINSTANCE.getVocabSpecification_DisplayName();
@@ -340,7 +304,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.NullFlavorImpl <em>Null Flavor</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.NullFlavorImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getNullFlavor()
 		 * @generated
@@ -351,7 +314,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Null Flavor</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute NULL_FLAVOR__NULL_FLAVOR = eINSTANCE.getNullFlavor_NullFlavor();
@@ -360,7 +322,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.TextValueImpl <em>Text Value</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.TextValueImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getTextValue()
 		 * @generated
@@ -371,7 +332,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute TEXT_VALUE__VALUE = eINSTANCE.getTextValue_Value();
@@ -380,7 +340,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Ignore Case</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute TEXT_VALUE__IGNORE_CASE = eINSTANCE.getTextValue_IgnoreCase();
@@ -389,7 +348,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl <em>Template</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getCDATemplate()
 		 * @generated
@@ -400,7 +358,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Template Id</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute CDA_TEMPLATE__TEMPLATE_ID = eINSTANCE.getCDATemplate_TemplateId();
@@ -409,7 +366,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Assigning Authority Name</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute CDA_TEMPLATE__ASSIGNING_AUTHORITY_NAME = eINSTANCE.getCDATemplate_AssigningAuthorityName();
@@ -418,7 +374,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Context Dependent</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute CDA_TEMPLATE__CONTEXT_DEPENDENT = eINSTANCE.getCDATemplate_ContextDependent();
@@ -427,17 +382,22 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Template Version</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute CDA_TEMPLATE__TEMPLATE_VERSION = eINSTANCE.getCDATemplate_TemplateVersion();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConstraintValidationImpl
-		 * <em>Constraint Validation</em>}' class.
+		 * The meta object literal for the '<em><b>Template Multiplicity</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
+		 * @generated
+		 */
+		EAttribute CDA_TEMPLATE__TEMPLATE_MULTIPLICITY = eINSTANCE.getCDATemplate_TemplateMultiplicity();
+
+		/**
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConstraintValidationImpl <em>Constraint Validation</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ConstraintValidationImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getConstraintValidation()
 		 * @generated
@@ -448,7 +408,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Base Constraint</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference CONSTRAINT_VALIDATION__BASE_CONSTRAINT = eINSTANCE.getConstraintValidation_Base_Constraint();
@@ -457,7 +416,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConformsToImpl <em>Conforms To</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ConformsToImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getConformsTo()
 		 * @generated
@@ -468,7 +426,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Base Generalization</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference CONFORMS_TO__BASE_GENERALIZATION = eINSTANCE.getConformsTo_Base_Generalization();
@@ -477,17 +434,14 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Requires Parent Id</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute CONFORMS_TO__REQUIRES_PARENT_ID = eINSTANCE.getConformsTo_RequiresParentId();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl
-		 * <em>Concept Domain Constraint</em>}' class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl <em>Concept Domain Constraint</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getConceptDomainConstraint()
 		 * @generated
@@ -495,11 +449,9 @@ public interface CDAPackage extends EPackage {
 		EClass CONCEPT_DOMAIN_CONSTRAINT = eINSTANCE.getConceptDomainConstraint();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl
-		 * <em>Code System Constraint</em>}' class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl <em>Code System Constraint</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getCodeSystemConstraint()
 		 * @generated
@@ -507,11 +459,9 @@ public interface CDAPackage extends EPackage {
 		EClass CODE_SYSTEM_CONSTRAINT = eINSTANCE.getCodeSystemConstraint();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl
-		 * <em>Value Set Constraint</em>}' class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl <em>Value Set Constraint</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getValueSetConstraint()
 		 * @generated
@@ -519,11 +469,9 @@ public interface CDAPackage extends EPackage {
 		EClass VALUE_SET_CONSTRAINT = eINSTANCE.getValueSetConstraint();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ActRelationshipImpl <em>Act Relationship</em>}'
-		 * class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ActRelationshipImpl <em>Act Relationship</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ActRelationshipImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getActRelationship()
 		 * @generated
@@ -534,7 +482,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Base Association</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference ACT_RELATIONSHIP__BASE_ASSOCIATION = eINSTANCE.getActRelationship_Base_Association();
@@ -543,7 +490,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Association Type</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference ACT_RELATIONSHIP__ASSOCIATION_TYPE = eINSTANCE.getActRelationship_AssociationType();
@@ -552,17 +498,14 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Type Code</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference ACT_RELATIONSHIP__TYPE_CODE = eINSTANCE.getActRelationship_TypeCode();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ParticipationImpl <em>Participation</em>}'
-		 * class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ParticipationImpl <em>Participation</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ParticipationImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getParticipation()
 		 * @generated
@@ -573,7 +516,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Base Association</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference PARTICIPATION__BASE_ASSOCIATION = eINSTANCE.getParticipation_Base_Association();
@@ -582,7 +524,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Association Type</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference PARTICIPATION__ASSOCIATION_TYPE = eINSTANCE.getParticipation_AssociationType();
@@ -591,17 +532,14 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Type Code</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference PARTICIPATION__TYPE_CODE = eINSTANCE.getParticipation_TypeCode();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.LogicalConstraintImpl
-		 * <em>Logical Constraint</em>}' class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.LogicalConstraintImpl <em>Logical Constraint</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.LogicalConstraintImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getLogicalConstraint()
 		 * @generated
@@ -612,7 +550,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Operation</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute LOGICAL_CONSTRAINT__OPERATION = eINSTANCE.getLogicalConstraint_Operation();
@@ -621,7 +558,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.InlineImpl <em>Inline</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.InlineImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getInline()
 		 * @generated
@@ -632,7 +568,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Base Class</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference INLINE__BASE_CLASS = eINSTANCE.getInline_Base_Class();
@@ -641,7 +576,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Filter</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute INLINE__FILTER = eINSTANCE.getInline_Filter();
@@ -650,17 +584,14 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Publish Seperately</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EAttribute INLINE__PUBLISH_SEPERATELY = eINSTANCE.getInline_PublishSeperately();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.UnimplementableImpl <em>Unimplementable</em>}'
-		 * class.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.UnimplementableImpl <em>Unimplementable</em>}' class.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.UnimplementableImpl
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getUnimplementable()
 		 * @generated
@@ -671,7 +602,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '<em><b>Base Constraint</b></em>' reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @generated
 		 */
 		EReference UNIMPLEMENTABLE__BASE_CONSTRAINT = eINSTANCE.getUnimplementable_Base_Constraint();
@@ -680,7 +610,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.SeverityKind <em>Severity Kind</em>}' enum.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.SeverityKind
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getSeverityKind()
 		 * @generated
@@ -691,7 +620,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryKind <em>Entry Kind</em>}' enum.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryKind
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getEntryKind()
 		 * @generated
@@ -699,11 +627,9 @@ public interface CDAPackage extends EPackage {
 		EEnum ENTRY_KIND = eINSTANCE.getEntryKind();
 
 		/**
-		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind
-		 * <em>Entry Relationship Kind</em>}' enum.
+		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind <em>Entry Relationship Kind</em>}' enum.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getEntryRelationshipKind()
 		 * @generated
@@ -714,7 +640,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.NullFlavorKind <em>Null Flavor Kind</em>}' enum.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.NullFlavorKind
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getNullFlavorKind()
 		 * @generated
@@ -725,7 +650,6 @@ public interface CDAPackage extends EPackage {
 		 * The meta object literal for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.LogicalOperator <em>Logical Operator</em>}' enum.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * 
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.LogicalOperator
 		 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getLogicalOperator()
 		 * @generated
@@ -738,7 +662,6 @@ public interface CDAPackage extends EPackage {
 	 * The package name.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	String eNAME = "profile";
@@ -747,7 +670,6 @@ public interface CDAPackage extends EPackage {
 	 * The package namespace URI.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	String eNS_URI = "http://www.openhealthtools.org/mdht/schemas/cda/4";
@@ -756,7 +678,6 @@ public interface CDAPackage extends EPackage {
 	 * The package namespace name.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	String eNS_PREFIX = "CDA";
@@ -765,7 +686,6 @@ public interface CDAPackage extends EPackage {
 	 * The singleton instance of the package.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	CDAPackage eINSTANCE = org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl.init();
@@ -774,7 +694,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValidationImpl <em>Validation</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ValidationImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getValidation()
 	 * @generated
@@ -785,7 +704,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -795,7 +713,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -805,7 +722,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -815,7 +731,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -825,18 +740,15 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Validation</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VALIDATION_FEATURE_COUNT = 4;
 
 	/**
-	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.AssociationValidationImpl
-	 * <em>Association Validation</em>}' class.
+	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.AssociationValidationImpl <em>Association Validation</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.AssociationValidationImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getAssociationValidation()
 	 * @generated
@@ -847,7 +759,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -857,7 +768,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -867,7 +777,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -877,7 +786,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -887,7 +795,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Association</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -897,7 +804,6 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Association Validation</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -907,7 +813,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryImpl <em>Entry</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getEntry()
 	 * @generated
@@ -918,7 +823,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -928,7 +832,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -938,7 +841,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -948,7 +850,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -958,7 +859,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Association</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -968,7 +868,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Type Code</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -978,18 +877,15 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Entry</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ENTRY_FEATURE_COUNT = ASSOCIATION_VALIDATION_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryRelationshipImpl <em>Entry Relationship</em>}'
-	 * class.
+	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryRelationshipImpl <em>Entry Relationship</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryRelationshipImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getEntryRelationship()
 	 * @generated
@@ -1000,7 +896,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1010,7 +905,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1020,7 +914,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1030,7 +923,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1040,7 +932,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Association</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1050,7 +941,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Type Code</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1060,7 +950,6 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Entry Relationship</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1070,7 +959,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl <em>Codegen Support</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getCodegenSupport()
 	 * @generated
@@ -1081,7 +969,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Package</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1091,7 +978,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Ns Prefix</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1101,7 +987,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Ns URI</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1111,7 +996,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Package Name</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1121,7 +1005,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Prefix</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1131,7 +1014,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Namespace</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1141,18 +1023,15 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Codegen Support</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CODEGEN_SUPPORT_FEATURE_COUNT = 6;
 
 	/**
-	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.PropertyValidationImpl <em>Property Validation</em>}'
-	 * class.
+	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.PropertyValidationImpl <em>Property Validation</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.PropertyValidationImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getPropertyValidation()
 	 * @generated
@@ -1163,7 +1042,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1173,7 +1051,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1183,7 +1060,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1193,7 +1069,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1203,7 +1078,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Property</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1213,7 +1087,6 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Property Validation</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1223,7 +1096,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ClassValidationImpl <em>Class Validation</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ClassValidationImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getClassValidation()
 	 * @generated
@@ -1234,7 +1106,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1244,7 +1115,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1254,7 +1124,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1264,7 +1133,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1274,7 +1142,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Class</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1284,18 +1151,15 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Class Validation</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CLASS_VALIDATION_FEATURE_COUNT = VALIDATION_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl <em>Vocab Specification</em>}'
-	 * class.
+	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl <em>Vocab Specification</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getVocabSpecification()
 	 * @generated
@@ -1306,7 +1170,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1316,7 +1179,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1326,7 +1188,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1336,7 +1197,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1346,7 +1206,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Property</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1356,7 +1215,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Code</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1366,7 +1224,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Code System</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1376,7 +1233,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Code System Name</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1386,7 +1242,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Code System Version</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1396,7 +1251,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Display Name</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1406,7 +1260,6 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Vocab Specification</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1416,7 +1269,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.NullFlavorImpl <em>Null Flavor</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.NullFlavorImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getNullFlavor()
 	 * @generated
@@ -1427,7 +1279,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1437,7 +1288,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1447,7 +1297,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1457,7 +1306,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1467,7 +1315,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Property</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1477,7 +1324,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Null Flavor</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1487,7 +1333,6 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Null Flavor</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1497,7 +1342,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.TextValueImpl <em>Text Value</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.TextValueImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getTextValue()
 	 * @generated
@@ -1508,7 +1352,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1518,7 +1361,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1528,7 +1370,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1538,7 +1379,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1548,7 +1388,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Property</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1558,7 +1397,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Value</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1568,7 +1406,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Ignore Case</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1578,7 +1415,6 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Text Value</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1588,7 +1424,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl <em>Template</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getCDATemplate()
 	 * @generated
@@ -1599,7 +1434,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1609,7 +1443,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1619,7 +1452,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1629,7 +1461,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1639,7 +1470,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Class</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1649,7 +1479,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Template Id</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1659,7 +1488,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Assigning Authority Name</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1669,7 +1497,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Context Dependent</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1679,28 +1506,33 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Template Version</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CDA_TEMPLATE__TEMPLATE_VERSION = CLASS_VALIDATION_FEATURE_COUNT + 3;
 
 	/**
-	 * The number of structural features of the '<em>Template</em>' class.
+	 * The feature id for the '<em><b>Template Multiplicity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
-	int CDA_TEMPLATE_FEATURE_COUNT = CLASS_VALIDATION_FEATURE_COUNT + 4;
+	int CDA_TEMPLATE__TEMPLATE_MULTIPLICITY = CLASS_VALIDATION_FEATURE_COUNT + 4;
 
 	/**
-	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConstraintValidationImpl <em>Constraint Validation</em>}'
-	 * class.
+	 * The number of structural features of the '<em>Template</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int CDA_TEMPLATE_FEATURE_COUNT = CLASS_VALIDATION_FEATURE_COUNT + 5;
+
+	/**
+	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConstraintValidationImpl <em>Constraint Validation</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ConstraintValidationImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getConstraintValidation()
 	 * @generated
@@ -1711,7 +1543,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1721,7 +1552,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1731,7 +1561,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1741,7 +1570,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1751,7 +1579,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Constraint</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1761,7 +1588,6 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Constraint Validation</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1771,7 +1597,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConformsToImpl <em>Conforms To</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ConformsToImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getConformsTo()
 	 * @generated
@@ -1782,7 +1607,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1792,7 +1616,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1802,7 +1625,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1812,7 +1634,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1822,7 +1643,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Generalization</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1832,7 +1652,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Requires Parent Id</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1842,18 +1661,15 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Conforms To</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONFORMS_TO_FEATURE_COUNT = VALIDATION_FEATURE_COUNT + 2;
 
 	/**
-	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl
-	 * <em>Concept Domain Constraint</em>}' class.
+	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl <em>Concept Domain Constraint</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getConceptDomainConstraint()
 	 * @generated
@@ -1864,7 +1680,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Reference</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1874,7 +1689,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Identifier</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1884,7 +1698,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1894,7 +1707,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Property</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1904,7 +1716,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1914,7 +1725,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1924,7 +1734,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1934,7 +1743,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1944,18 +1752,15 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Concept Domain Constraint</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONCEPT_DOMAIN_CONSTRAINT_FEATURE_COUNT = TermPackage.CONCEPT_DOMAIN_CONSTRAINT_FEATURE_COUNT + 4;
 
 	/**
-	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl <em>Code System Constraint</em>}
-	 * ' class.
+	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl <em>Code System Constraint</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getCodeSystemConstraint()
 	 * @generated
@@ -1966,7 +1771,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Reference</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1976,7 +1780,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Identifier</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1986,7 +1789,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1996,7 +1798,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Version</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2006,7 +1807,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Binding</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2016,7 +1816,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Code</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2026,7 +1825,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Display Name</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2036,7 +1834,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Qualifier</b></em>' reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2046,7 +1843,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Property</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2056,7 +1852,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2066,7 +1861,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2076,7 +1870,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2086,7 +1879,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2096,18 +1888,15 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Code System Constraint</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CODE_SYSTEM_CONSTRAINT_FEATURE_COUNT = TermPackage.CODE_SYSTEM_CONSTRAINT_FEATURE_COUNT + 4;
 
 	/**
-	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl <em>Value Set Constraint</em>}'
-	 * class.
+	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl <em>Value Set Constraint</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getValueSetConstraint()
 	 * @generated
@@ -2118,7 +1907,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Reference</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2128,7 +1916,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Identifier</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2138,7 +1925,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Name</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2148,7 +1934,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Version</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2158,7 +1943,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Binding</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2168,7 +1952,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Property</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2178,7 +1961,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2188,7 +1970,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2198,7 +1979,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2208,7 +1988,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2218,7 +1997,6 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Value Set Constraint</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2228,7 +2006,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ActRelationshipImpl <em>Act Relationship</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ActRelationshipImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getActRelationship()
 	 * @generated
@@ -2239,7 +2016,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Association</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2249,7 +2025,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Association Type</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2259,7 +2034,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Type Code</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2269,7 +2043,6 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Act Relationship</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2279,7 +2052,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ParticipationImpl <em>Participation</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.ParticipationImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getParticipation()
 	 * @generated
@@ -2290,7 +2062,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Association</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2300,7 +2071,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Association Type</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2310,7 +2080,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Type Code</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2320,18 +2089,15 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Participation</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTICIPATION_FEATURE_COUNT = 3;
 
 	/**
-	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.LogicalConstraintImpl <em>Logical Constraint</em>}'
-	 * class.
+	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.LogicalConstraintImpl <em>Logical Constraint</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.LogicalConstraintImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getLogicalConstraint()
 	 * @generated
@@ -2342,7 +2108,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Message</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2352,7 +2117,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Severity</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2362,7 +2126,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Rule Id</b></em>' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2372,7 +2135,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2382,7 +2144,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Constraint</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2392,7 +2153,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Operation</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2402,7 +2162,6 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Logical Constraint</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2412,7 +2171,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.InlineImpl <em>Inline</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.InlineImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getInline()
 	 * @generated
@@ -2423,7 +2181,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Class</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2433,7 +2190,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Filter</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2443,7 +2199,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Publish Seperately</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2453,7 +2208,6 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Inline</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2463,7 +2217,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.UnimplementableImpl <em>Unimplementable</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.UnimplementableImpl
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getUnimplementable()
 	 * @generated
@@ -2474,7 +2227,6 @@ public interface CDAPackage extends EPackage {
 	 * The feature id for the '<em><b>Base Constraint</b></em>' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2484,7 +2236,6 @@ public interface CDAPackage extends EPackage {
 	 * The number of structural features of the '<em>Unimplementable</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2494,7 +2245,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.SeverityKind <em>Severity Kind</em>}' enum.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.SeverityKind
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getSeverityKind()
 	 * @generated
@@ -2505,7 +2255,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryKind <em>Entry Kind</em>}' enum.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryKind
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getEntryKind()
 	 * @generated
@@ -2516,7 +2265,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind <em>Entry Relationship Kind</em>}' enum.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getEntryRelationshipKind()
 	 * @generated
@@ -2527,7 +2275,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.NullFlavorKind <em>Null Flavor Kind</em>}' enum.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.NullFlavorKind
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getNullFlavorKind()
 	 * @generated
@@ -2538,7 +2285,6 @@ public interface CDAPackage extends EPackage {
 	 * The meta object id for the '{@link org.openhealthtools.mdht.uml.cda.core.profile.LogicalOperator <em>Logical Operator</em>}' enum.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.LogicalOperator
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.impl.CDAPackageImpl#getLogicalOperator()
 	 * @generated
@@ -2549,7 +2295,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship <em>Act Relationship</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Act Relationship</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship
 	 * @generated
@@ -2557,11 +2302,9 @@ public interface CDAPackage extends EPackage {
 	EClass getActRelationship();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getAssociationType
-	 * <em>Association Type</em>}'.
+	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getAssociationType <em>Association Type</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Association Type</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getAssociationType()
 	 * @see #getActRelationship()
@@ -2570,11 +2313,9 @@ public interface CDAPackage extends EPackage {
 	EReference getActRelationship_AssociationType();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getBase_Association
-	 * <em>Base Association</em>}'.
+	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getBase_Association <em>Base Association</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Base Association</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getBase_Association()
 	 * @see #getActRelationship()
@@ -2583,11 +2324,9 @@ public interface CDAPackage extends EPackage {
 	EReference getActRelationship_Base_Association();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getTypeCode <em>Type Code</em>}
-	 * '.
+	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getTypeCode <em>Type Code</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Type Code</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship#getTypeCode()
 	 * @see #getActRelationship()
@@ -2596,11 +2335,9 @@ public interface CDAPackage extends EPackage {
 	EReference getActRelationship_TypeCode();
 
 	/**
-	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation <em>Association Validation</em>}
-	 * '.
+	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation <em>Association Validation</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Association Validation</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation
 	 * @generated
@@ -2608,11 +2345,9 @@ public interface CDAPackage extends EPackage {
 	EClass getAssociationValidation();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation#getBase_Association
-	 * <em>Base Association</em>}'.
+	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation#getBase_Association <em>Base Association</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Base Association</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation#getBase_Association()
 	 * @see #getAssociationValidation()
@@ -2624,7 +2359,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the factory that creates the instances of the model.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the factory that creates the instances of the model.
 	 * @generated
 	 */
@@ -2634,7 +2368,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate <em>Template</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Template</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate
 	 * @generated
@@ -2642,11 +2375,9 @@ public interface CDAPackage extends EPackage {
 	EClass getCDATemplate();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getAssigningAuthorityName
-	 * <em>Assigning Authority Name</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getAssigningAuthorityName <em>Assigning Authority Name</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Assigning Authority Name</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getAssigningAuthorityName()
 	 * @see #getCDATemplate()
@@ -2655,11 +2386,9 @@ public interface CDAPackage extends EPackage {
 	EAttribute getCDATemplate_AssigningAuthorityName();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#isContextDependent
-	 * <em>Context Dependent</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#isContextDependent <em>Context Dependent</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Context Dependent</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#isContextDependent()
 	 * @see #getCDATemplate()
@@ -2668,11 +2397,9 @@ public interface CDAPackage extends EPackage {
 	EAttribute getCDATemplate_ContextDependent();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateVersion
-	 * <em>Template Version</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateVersion <em>Template Version</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Template Version</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateVersion()
 	 * @see #getCDATemplate()
@@ -2681,11 +2408,20 @@ public interface CDAPackage extends EPackage {
 	EAttribute getCDATemplate_TemplateVersion();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateId <em>Template Id</em>}
-	 * '.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateMultiplicity <em>Template Multiplicity</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
+	 * @return the meta object for the attribute '<em>Template Multiplicity</em>'.
+	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateMultiplicity()
+	 * @see #getCDATemplate()
+	 * @generated
+	 */
+	EAttribute getCDATemplate_TemplateMultiplicity();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateId <em>Template Id</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @return the meta object for the attribute '<em>Template Id</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateId()
 	 * @see #getCDATemplate()
@@ -2697,7 +2433,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ClassValidation <em>Class Validation</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Class Validation</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ClassValidation
 	 * @generated
@@ -2705,11 +2440,9 @@ public interface CDAPackage extends EPackage {
 	EClass getClassValidation();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.ClassValidation#getBase_Class
-	 * <em>Base Class</em>}'.
+	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.ClassValidation#getBase_Class <em>Base Class</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Base Class</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ClassValidation#getBase_Class()
 	 * @see #getClassValidation()
@@ -2721,7 +2454,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport <em>Codegen Support</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Codegen Support</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport
 	 * @generated
@@ -2729,11 +2461,9 @@ public interface CDAPackage extends EPackage {
 	EClass getCodegenSupport();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBase_Namespace
-	 * <em>Base Namespace</em>}'.
+	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBase_Namespace <em>Base Namespace</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Base Namespace</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBase_Namespace()
 	 * @see #getCodegenSupport()
@@ -2742,11 +2472,9 @@ public interface CDAPackage extends EPackage {
 	EReference getCodegenSupport_Base_Namespace();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBasePackage
-	 * <em>Base Package</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBasePackage <em>Base Package</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Base Package</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBasePackage()
 	 * @see #getCodegenSupport()
@@ -2755,11 +2483,9 @@ public interface CDAPackage extends EPackage {
 	EAttribute getCodegenSupport_BasePackage();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getNsPrefix <em>Ns Prefix</em>}
-	 * '.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getNsPrefix <em>Ns Prefix</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Ns Prefix</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getNsPrefix()
 	 * @see #getCodegenSupport()
@@ -2771,7 +2497,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getNsURI <em>Ns URI</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Ns URI</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getNsURI()
 	 * @see #getCodegenSupport()
@@ -2780,11 +2505,9 @@ public interface CDAPackage extends EPackage {
 	EAttribute getCodegenSupport_NsURI();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getPackageName
-	 * <em>Package Name</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getPackageName <em>Package Name</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Package Name</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getPackageName()
 	 * @see #getCodegenSupport()
@@ -2796,7 +2519,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getPrefix <em>Prefix</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Prefix</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getPrefix()
 	 * @see #getCodegenSupport()
@@ -2808,7 +2530,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodeSystemConstraint <em>Code System Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Code System Constraint</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CodeSystemConstraint
 	 * @generated
@@ -2816,11 +2537,9 @@ public interface CDAPackage extends EPackage {
 	EClass getCodeSystemConstraint();
 
 	/**
-	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConceptDomainConstraint
-	 * <em>Concept Domain Constraint</em>}'.
+	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConceptDomainConstraint <em>Concept Domain Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Concept Domain Constraint</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ConceptDomainConstraint
 	 * @generated
@@ -2831,7 +2550,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo <em>Conforms To</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Conforms To</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo
 	 * @generated
@@ -2839,11 +2557,9 @@ public interface CDAPackage extends EPackage {
 	EClass getConformsTo();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#getBase_Generalization
-	 * <em>Base Generalization</em>}'.
+	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#getBase_Generalization <em>Base Generalization</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Base Generalization</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#getBase_Generalization()
 	 * @see #getConformsTo()
@@ -2852,11 +2568,9 @@ public interface CDAPackage extends EPackage {
 	EReference getConformsTo_Base_Generalization();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#isRequiresParentId
-	 * <em>Requires Parent Id</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#isRequiresParentId <em>Requires Parent Id</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Requires Parent Id</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#isRequiresParentId()
 	 * @see #getConformsTo()
@@ -2868,7 +2582,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation <em>Constraint Validation</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Constraint Validation</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation
 	 * @generated
@@ -2876,11 +2589,9 @@ public interface CDAPackage extends EPackage {
 	EClass getConstraintValidation();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation#getBase_Constraint
-	 * <em>Base Constraint</em>}'.
+	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation#getBase_Constraint <em>Base Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Base Constraint</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation#getBase_Constraint()
 	 * @see #getConstraintValidation()
@@ -2892,7 +2603,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.Entry <em>Entry</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Entry</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Entry
 	 * @generated
@@ -2903,7 +2613,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.Entry#getTypeCode <em>Type Code</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Type Code</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Entry#getTypeCode()
 	 * @see #getEntry()
@@ -2915,7 +2624,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for enum '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryKind <em>Entry Kind</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for enum '<em>Entry Kind</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryKind
 	 * @generated
@@ -2926,7 +2634,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship <em>Entry Relationship</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Entry Relationship</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship
 	 * @generated
@@ -2934,11 +2641,9 @@ public interface CDAPackage extends EPackage {
 	EClass getEntryRelationship();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship#getTypeCode
-	 * <em>Type Code</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship#getTypeCode <em>Type Code</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Type Code</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship#getTypeCode()
 	 * @see #getEntryRelationship()
@@ -2947,11 +2652,9 @@ public interface CDAPackage extends EPackage {
 	EAttribute getEntryRelationship_TypeCode();
 
 	/**
-	 * Returns the meta object for enum '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind <em>Entry Relationship Kind</em>}
-	 * '.
+	 * Returns the meta object for enum '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind <em>Entry Relationship Kind</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for enum '<em>Entry Relationship Kind</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind
 	 * @generated
@@ -2962,7 +2665,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.NullFlavor <em>Null Flavor</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Null Flavor</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.NullFlavor
 	 * @generated
@@ -2970,11 +2672,9 @@ public interface CDAPackage extends EPackage {
 	EClass getNullFlavor();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.NullFlavor#getNullFlavor <em>Null Flavor</em>}
-	 * '.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.NullFlavor#getNullFlavor <em>Null Flavor</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Null Flavor</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.NullFlavor#getNullFlavor()
 	 * @see #getNullFlavor()
@@ -2986,7 +2686,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for enum '{@link org.openhealthtools.mdht.uml.cda.core.profile.NullFlavorKind <em>Null Flavor Kind</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for enum '<em>Null Flavor Kind</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.NullFlavorKind
 	 * @generated
@@ -2997,7 +2696,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for enum '{@link org.openhealthtools.mdht.uml.cda.core.profile.LogicalOperator <em>Logical Operator</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for enum '<em>Logical Operator</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.LogicalOperator
 	 * @generated
@@ -3008,7 +2706,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation <em>Participation</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Participation</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Participation
 	 * @generated
@@ -3016,11 +2713,9 @@ public interface CDAPackage extends EPackage {
 	EClass getParticipation();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getAssociationType
-	 * <em>Association Type</em>}'.
+	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getAssociationType <em>Association Type</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Association Type</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Participation#getAssociationType()
 	 * @see #getParticipation()
@@ -3029,11 +2724,9 @@ public interface CDAPackage extends EPackage {
 	EReference getParticipation_AssociationType();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getBase_Association
-	 * <em>Base Association</em>}'.
+	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getBase_Association <em>Base Association</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Base Association</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Participation#getBase_Association()
 	 * @see #getParticipation()
@@ -3045,7 +2738,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getTypeCode <em>Type Code</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Type Code</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Participation#getTypeCode()
 	 * @see #getParticipation()
@@ -3057,7 +2749,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.LogicalConstraint <em>Logical Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Logical Constraint</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.LogicalConstraint
 	 * @generated
@@ -3065,11 +2756,9 @@ public interface CDAPackage extends EPackage {
 	EClass getLogicalConstraint();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.LogicalConstraint#getOperation
-	 * <em>Operation</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.LogicalConstraint#getOperation <em>Operation</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Operation</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.LogicalConstraint#getOperation()
 	 * @see #getLogicalConstraint()
@@ -3081,7 +2770,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline <em>Inline</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Inline</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Inline
 	 * @generated
@@ -3092,7 +2780,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#getBase_Class <em>Base Class</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Base Class</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Inline#getBase_Class()
 	 * @see #getInline()
@@ -3104,7 +2791,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#getFilter <em>Filter</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Filter</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Inline#getFilter()
 	 * @see #getInline()
@@ -3113,11 +2799,9 @@ public interface CDAPackage extends EPackage {
 	EAttribute getInline_Filter();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#isPublishSeperately
-	 * <em>Publish Seperately</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#isPublishSeperately <em>Publish Seperately</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Publish Seperately</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Inline#isPublishSeperately()
 	 * @see #getInline()
@@ -3129,7 +2813,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.Unimplementable <em>Unimplementable</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Unimplementable</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Unimplementable
 	 * @generated
@@ -3137,11 +2820,9 @@ public interface CDAPackage extends EPackage {
 	EClass getUnimplementable();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.Unimplementable#getBase_Constraint
-	 * <em>Base Constraint</em>}'.
+	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.Unimplementable#getBase_Constraint <em>Base Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Base Constraint</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Unimplementable#getBase_Constraint()
 	 * @see #getUnimplementable()
@@ -3153,7 +2834,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation <em>Property Validation</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Property Validation</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation
 	 * @generated
@@ -3161,11 +2841,9 @@ public interface CDAPackage extends EPackage {
 	EClass getPropertyValidation();
 
 	/**
-	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation#getBase_Property
-	 * <em>Base Property</em>}'.
+	 * Returns the meta object for the reference '{@link org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation#getBase_Property <em>Base Property</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the reference '<em>Base Property</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation#getBase_Property()
 	 * @see #getPropertyValidation()
@@ -3177,7 +2855,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for enum '{@link org.openhealthtools.mdht.uml.cda.core.profile.SeverityKind <em>Severity Kind</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for enum '<em>Severity Kind</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.SeverityKind
 	 * @generated
@@ -3188,7 +2865,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.TextValue <em>Text Value</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Text Value</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.TextValue
 	 * @generated
@@ -3199,7 +2875,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.TextValue#isIgnoreCase <em>Ignore Case</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Ignore Case</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.TextValue#isIgnoreCase()
 	 * @see #getTextValue()
@@ -3211,7 +2886,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.TextValue#getValue <em>Value</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Value</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.TextValue#getValue()
 	 * @see #getTextValue()
@@ -3223,7 +2897,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation <em>Validation</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Validation</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Validation
 	 * @generated
@@ -3234,7 +2907,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#isMandatory <em>Mandatory</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Mandatory</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Validation#isMandatory()
 	 * @see #getValidation()
@@ -3246,7 +2918,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#getMessage <em>Message</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Message</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Validation#getMessage()
 	 * @see #getValidation()
@@ -3258,7 +2929,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the attribute list '{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#getRuleId <em>Rule Id</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute list '<em>Rule Id</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Validation#getRuleId()
 	 * @see #getValidation()
@@ -3270,7 +2940,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#getSeverity <em>Severity</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Severity</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Validation#getSeverity()
 	 * @see #getValidation()
@@ -3282,7 +2951,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ValueSetConstraint <em>Value Set Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Value Set Constraint</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ValueSetConstraint
 	 * @generated
@@ -3293,7 +2961,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for class '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification <em>Vocab Specification</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for class '<em>Vocab Specification</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification
 	 * @generated
@@ -3304,7 +2971,6 @@ public interface CDAPackage extends EPackage {
 	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCode <em>Code</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Code</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCode()
 	 * @see #getVocabSpecification()
@@ -3313,11 +2979,9 @@ public interface CDAPackage extends EPackage {
 	EAttribute getVocabSpecification_Code();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystem
-	 * <em>Code System</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystem <em>Code System</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Code System</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystem()
 	 * @see #getVocabSpecification()
@@ -3326,11 +2990,9 @@ public interface CDAPackage extends EPackage {
 	EAttribute getVocabSpecification_CodeSystem();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemName
-	 * <em>Code System Name</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemName <em>Code System Name</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Code System Name</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemName()
 	 * @see #getVocabSpecification()
@@ -3339,11 +3001,9 @@ public interface CDAPackage extends EPackage {
 	EAttribute getVocabSpecification_CodeSystemName();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemVersion
-	 * <em>Code System Version</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemVersion <em>Code System Version</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Code System Version</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemVersion()
 	 * @see #getVocabSpecification()
@@ -3352,11 +3012,9 @@ public interface CDAPackage extends EPackage {
 	EAttribute getVocabSpecification_CodeSystemVersion();
 
 	/**
-	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getDisplayName
-	 * <em>Display Name</em>}'.
+	 * Returns the meta object for the attribute '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getDisplayName <em>Display Name</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the meta object for the attribute '<em>Display Name</em>'.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getDisplayName()
 	 * @see #getVocabSpecification()

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/CDATemplate.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/CDATemplate.java
@@ -16,17 +16,18 @@ package org.openhealthtools.mdht.uml.cda.core.profile;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Template</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateId <em>Template Id</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getAssigningAuthorityName <em>Assigning Authority Name</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#isContextDependent <em>Context Dependent</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateVersion <em>Template Version</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateId <em>Template Id</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getAssigningAuthorityName <em>Assigning Authority Name</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#isContextDependent <em>Context Dependent</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateVersion <em>Template Version</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateMultiplicity <em>Template Multiplicity</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCDATemplate()
  * @model
  * @generated
@@ -39,7 +40,6 @@ public interface CDATemplate extends ClassValidation {
 	 * If the meaning of the '<em>Assigning Authority Name</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Assigning Authority Name</em>' attribute.
 	 * @see #setAssigningAuthorityName(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCDATemplate_AssigningAuthorityName()
@@ -55,7 +55,6 @@ public interface CDATemplate extends ClassValidation {
 	 * If the meaning of the '<em>Template Id</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Template Id</em>' attribute.
 	 * @see #setTemplateId(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCDATemplate_TemplateId()
@@ -72,7 +71,6 @@ public interface CDATemplate extends ClassValidation {
 	 * If the meaning of the '<em>Context Dependent</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Context Dependent</em>' attribute.
 	 * @see #setContextDependent(boolean)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCDATemplate_ContextDependent()
@@ -82,26 +80,20 @@ public interface CDATemplate extends ClassValidation {
 	boolean isContextDependent();
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getAssigningAuthorityName
-	 * <em>Assigning Authority Name</em>}' attribute.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getAssigningAuthorityName <em>Assigning Authority Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Assigning Authority Name</em>' attribute.
+	 * @param value the new value of the '<em>Assigning Authority Name</em>' attribute.
 	 * @see #getAssigningAuthorityName()
 	 * @generated
 	 */
 	void setAssigningAuthorityName(String value);
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#isContextDependent <em>Context Dependent</em>}'
-	 * attribute.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#isContextDependent <em>Context Dependent</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Context Dependent</em>' attribute.
+	 * @param value the new value of the '<em>Context Dependent</em>' attribute.
 	 * @see #isContextDependent()
 	 * @generated
 	 */
@@ -114,7 +106,6 @@ public interface CDATemplate extends ClassValidation {
 	 * If the meaning of the '<em>Template Version</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Template Version</em>' attribute.
 	 * @see #setTemplateVersion(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCDATemplate_TemplateVersion()
@@ -124,25 +115,46 @@ public interface CDATemplate extends ClassValidation {
 	String getTemplateVersion();
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateVersion <em>Template Version</em>}'
-	 * attribute.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateVersion <em>Template Version</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Template Version</em>' attribute.
+	 * @param value the new value of the '<em>Template Version</em>' attribute.
 	 * @see #getTemplateVersion()
 	 * @generated
 	 */
 	void setTemplateVersion(String value);
 
 	/**
+	 * Returns the value of the '<em><b>Template Multiplicity</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Template Multiplicity</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Template Multiplicity</em>' attribute.
+	 * @see #setTemplateMultiplicity(String)
+	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCDATemplate_TemplateMultiplicity()
+	 * @model dataType="org.eclipse.uml2.types.String" ordered="false"
+	 * @generated
+	 */
+	String getTemplateMultiplicity();
+
+	/**
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateMultiplicity <em>Template Multiplicity</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Template Multiplicity</em>' attribute.
+	 * @see #getTemplateMultiplicity()
+	 * @generated
+	 */
+	void setTemplateMultiplicity(String value);
+
+	/**
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate#getTemplateId <em>Template Id</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Template Id</em>' attribute.
+	 * @param value the new value of the '<em>Template Id</em>' attribute.
 	 * @see #getTemplateId()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/ClassValidation.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/ClassValidation.java
@@ -16,14 +16,14 @@ package org.openhealthtools.mdht.uml.cda.core.profile;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Class Validation</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ClassValidation#getBase_Class <em>Base Class</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ClassValidation#getBase_Class <em>Base Class</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getClassValidation()
  * @model
  * @generated
@@ -36,7 +36,6 @@ public interface ClassValidation extends Validation {
 	 * If the meaning of the '<em>Base Class</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Base Class</em>' reference.
 	 * @see #setBase_Class(org.eclipse.uml2.uml.Class)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getClassValidation_Base_Class()
@@ -49,9 +48,7 @@ public interface ClassValidation extends Validation {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.ClassValidation#getBase_Class <em>Base Class</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Base Class</em>' reference.
+	 * @param value the new value of the '<em>Base Class</em>' reference.
 	 * @see #getBase_Class()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/CodeSystemConstraint.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/CodeSystemConstraint.java
@@ -16,8 +16,8 @@ package org.openhealthtools.mdht.uml.cda.core.profile;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Code System Constraint</b></em>'.
  * <!-- end-user-doc -->
- * 
- * 
+ *
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCodeSystemConstraint()
  * @model
  * @generated

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/CodegenSupport.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/CodegenSupport.java
@@ -19,19 +19,19 @@ import org.eclipse.uml2.uml.Namespace;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Codegen Support</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBasePackage <em>Base Package</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getNsPrefix <em>Ns Prefix</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getNsURI <em>Ns URI</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getPackageName <em>Package Name</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getPrefix <em>Prefix</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBase_Namespace <em>Base Namespace</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBasePackage <em>Base Package</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getNsPrefix <em>Ns Prefix</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getNsURI <em>Ns URI</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getPackageName <em>Package Name</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getPrefix <em>Prefix</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBase_Namespace <em>Base Namespace</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCodegenSupport()
  * @model
  * @generated
@@ -44,7 +44,6 @@ public interface CodegenSupport extends EObject {
 	 * If the meaning of the '<em>Base Namespace</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Base Namespace</em>' reference.
 	 * @see #setBase_Namespace(Namespace)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCodegenSupport_Base_Namespace()
@@ -60,7 +59,6 @@ public interface CodegenSupport extends EObject {
 	 * If the meaning of the '<em>Base Package</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Base Package</em>' attribute.
 	 * @see #setBasePackage(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCodegenSupport_BasePackage()
@@ -76,7 +74,6 @@ public interface CodegenSupport extends EObject {
 	 * If the meaning of the '<em>Ns Prefix</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Ns Prefix</em>' attribute.
 	 * @see #setNsPrefix(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCodegenSupport_NsPrefix()
@@ -92,7 +89,6 @@ public interface CodegenSupport extends EObject {
 	 * If the meaning of the '<em>Ns URI</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Ns URI</em>' attribute.
 	 * @see #setNsURI(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCodegenSupport_NsURI()
@@ -108,7 +104,6 @@ public interface CodegenSupport extends EObject {
 	 * If the meaning of the '<em>Package Name</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Package Name</em>' attribute.
 	 * @see #setPackageName(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCodegenSupport_PackageName()
@@ -124,7 +119,6 @@ public interface CodegenSupport extends EObject {
 	 * If the meaning of the '<em>Prefix</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Prefix</em>' attribute.
 	 * @see #setPrefix(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getCodegenSupport_Prefix()
@@ -134,13 +128,10 @@ public interface CodegenSupport extends EObject {
 	String getPrefix();
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBase_Namespace <em>Base Namespace</em>}'
-	 * reference.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBase_Namespace <em>Base Namespace</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Base Namespace</em>' reference.
+	 * @param value the new value of the '<em>Base Namespace</em>' reference.
 	 * @see #getBase_Namespace()
 	 * @generated
 	 */
@@ -150,9 +141,7 @@ public interface CodegenSupport extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getBasePackage <em>Base Package</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Base Package</em>' attribute.
+	 * @param value the new value of the '<em>Base Package</em>' attribute.
 	 * @see #getBasePackage()
 	 * @generated
 	 */
@@ -162,9 +151,7 @@ public interface CodegenSupport extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getNsPrefix <em>Ns Prefix</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Ns Prefix</em>' attribute.
+	 * @param value the new value of the '<em>Ns Prefix</em>' attribute.
 	 * @see #getNsPrefix()
 	 * @generated
 	 */
@@ -174,9 +161,7 @@ public interface CodegenSupport extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getNsURI <em>Ns URI</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Ns URI</em>' attribute.
+	 * @param value the new value of the '<em>Ns URI</em>' attribute.
 	 * @see #getNsURI()
 	 * @generated
 	 */
@@ -186,9 +171,7 @@ public interface CodegenSupport extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getPackageName <em>Package Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Package Name</em>' attribute.
+	 * @param value the new value of the '<em>Package Name</em>' attribute.
 	 * @see #getPackageName()
 	 * @generated
 	 */
@@ -198,9 +181,7 @@ public interface CodegenSupport extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport#getPrefix <em>Prefix</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Prefix</em>' attribute.
+	 * @param value the new value of the '<em>Prefix</em>' attribute.
 	 * @see #getPrefix()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/ConceptDomainConstraint.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/ConceptDomainConstraint.java
@@ -16,8 +16,8 @@ package org.openhealthtools.mdht.uml.cda.core.profile;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Concept Domain Constraint</b></em>'.
  * <!-- end-user-doc -->
- * 
- * 
+ *
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getConceptDomainConstraint()
  * @model
  * @generated

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/ConformsTo.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/ConformsTo.java
@@ -18,15 +18,15 @@ import org.eclipse.uml2.uml.Generalization;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Conforms To</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#getBase_Generalization <em>Base Generalization</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#isRequiresParentId <em>Requires Parent Id</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#getBase_Generalization <em>Base Generalization</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#isRequiresParentId <em>Requires Parent Id</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getConformsTo()
  * @model
  * @generated
@@ -39,7 +39,6 @@ public interface ConformsTo extends Validation {
 	 * If the meaning of the '<em>Base Generalization</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Base Generalization</em>' reference.
 	 * @see #setBase_Generalization(Generalization)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getConformsTo_Base_Generalization()
@@ -56,7 +55,6 @@ public interface ConformsTo extends Validation {
 	 * If the meaning of the '<em>Requires Parent Id</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Requires Parent Id</em>' attribute.
 	 * @see #setRequiresParentId(boolean)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getConformsTo_RequiresParentId()
@@ -66,26 +64,20 @@ public interface ConformsTo extends Validation {
 	boolean isRequiresParentId();
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#getBase_Generalization <em>Base Generalization</em>}'
-	 * reference.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#getBase_Generalization <em>Base Generalization</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Base Generalization</em>' reference.
+	 * @param value the new value of the '<em>Base Generalization</em>' reference.
 	 * @see #getBase_Generalization()
 	 * @generated
 	 */
 	void setBase_Generalization(Generalization value);
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#isRequiresParentId <em>Requires Parent Id</em>}'
-	 * attribute.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo#isRequiresParentId <em>Requires Parent Id</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Requires Parent Id</em>' attribute.
+	 * @param value the new value of the '<em>Requires Parent Id</em>' attribute.
 	 * @see #isRequiresParentId()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/ConstraintValidation.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/ConstraintValidation.java
@@ -18,14 +18,14 @@ import org.eclipse.uml2.uml.Constraint;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Constraint Validation</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation#getBase_Constraint <em>Base Constraint</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation#getBase_Constraint <em>Base Constraint</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getConstraintValidation()
  * @model
  * @generated
@@ -38,7 +38,6 @@ public interface ConstraintValidation extends Validation {
 	 * If the meaning of the '<em>Base Constraint</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Base Constraint</em>' reference.
 	 * @see #setBase_Constraint(Constraint)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getConstraintValidation_Base_Constraint()
@@ -48,13 +47,10 @@ public interface ConstraintValidation extends Validation {
 	Constraint getBase_Constraint();
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation#getBase_Constraint <em>Base Constraint</em>}'
-	 * reference.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation#getBase_Constraint <em>Base Constraint</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Base Constraint</em>' reference.
+	 * @param value the new value of the '<em>Base Constraint</em>' reference.
 	 * @see #getBase_Constraint()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/Entry.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/Entry.java
@@ -16,14 +16,14 @@ package org.openhealthtools.mdht.uml.cda.core.profile;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Entry</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Entry#getTypeCode <em>Type Code</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Entry#getTypeCode <em>Type Code</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getEntry()
  * @model
  * @generated
@@ -37,7 +37,6 @@ public interface Entry extends AssociationValidation {
 	 * If the meaning of the '<em>Type Code</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Type Code</em>' attribute.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryKind
 	 * @see #setTypeCode(EntryKind)
@@ -51,9 +50,7 @@ public interface Entry extends AssociationValidation {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Entry#getTypeCode <em>Type Code</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Type Code</em>' attribute.
+	 * @param value the new value of the '<em>Type Code</em>' attribute.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryKind
 	 * @see #getTypeCode()
 	 * @generated

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/EntryKind.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/EntryKind.java
@@ -23,7 +23,6 @@ import org.eclipse.emf.common.util.Enumerator;
  * A representation of the literals of the enumeration '<em><b>Entry Kind</b></em>',
  * and utility methods for working with them.
  * <!-- end-user-doc -->
- * 
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getEntryKind()
  * @model
  * @generated
@@ -33,7 +32,6 @@ public enum EntryKind implements Enumerator {
 	 * The '<em><b>COMP</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #COMP_VALUE
 	 * @generated
 	 * @ordered
@@ -44,7 +42,6 @@ public enum EntryKind implements Enumerator {
 	 * The '<em><b>DRIV</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #DRIV_VALUE
 	 * @generated
 	 * @ordered
@@ -58,7 +55,6 @@ public enum EntryKind implements Enumerator {
 	 * If the meaning of '<em><b>COMP</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #COMP
 	 * @model
 	 * @generated
@@ -73,7 +69,6 @@ public enum EntryKind implements Enumerator {
 	 * If the meaning of '<em><b>DRIV</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #DRIV
 	 * @model
 	 * @generated
@@ -85,16 +80,17 @@ public enum EntryKind implements Enumerator {
 	 * An array of all the '<em><b>Entry Kind</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
-	private static final EntryKind[] VALUES_ARRAY = new EntryKind[] { COMP, DRIV, };
+	private static final EntryKind[] VALUES_ARRAY = new EntryKind[] {
+			COMP,
+			DRIV,
+		};
 
 	/**
 	 * A public read-only list of all the '<em><b>Entry Kind</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static final List<EntryKind> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
@@ -103,15 +99,12 @@ public enum EntryKind implements Enumerator {
 	 * Returns the '<em><b>Entry Kind</b></em>' literal with the specified integer value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static EntryKind get(int value) {
 		switch (value) {
-			case COMP_VALUE:
-				return COMP;
-			case DRIV_VALUE:
-				return DRIV;
+			case COMP_VALUE: return COMP;
+			case DRIV_VALUE: return DRIV;
 		}
 		return null;
 	}
@@ -120,7 +113,6 @@ public enum EntryKind implements Enumerator {
 	 * Returns the '<em><b>Entry Kind</b></em>' literal with the specified literal value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static EntryKind get(String literal) {
@@ -137,7 +129,6 @@ public enum EntryKind implements Enumerator {
 	 * Returns the '<em><b>Entry Kind</b></em>' literal with the specified name.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static EntryKind getByName(String name) {
@@ -153,7 +144,6 @@ public enum EntryKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final int value;
@@ -161,7 +151,6 @@ public enum EntryKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final String name;
@@ -169,7 +158,6 @@ public enum EntryKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final String literal;
@@ -178,7 +166,6 @@ public enum EntryKind implements Enumerator {
 	 * Only this class can construct instances.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EntryKind(int value, String name, String literal) {
@@ -190,38 +177,34 @@ public enum EntryKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
-		return literal;
+	  return literal;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getName() {
-		return name;
+	  return name;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public int getValue() {
-		return value;
+	  return value;
 	}
 
 	/**
 	 * Returns the literal value of the enumerator, which is its string representation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/EntryRelationship.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/EntryRelationship.java
@@ -16,14 +16,14 @@ package org.openhealthtools.mdht.uml.cda.core.profile;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Entry Relationship</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship#getTypeCode <em>Type Code</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship#getTypeCode <em>Type Code</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getEntryRelationship()
  * @model
  * @generated
@@ -37,7 +37,6 @@ public interface EntryRelationship extends AssociationValidation {
 	 * If the meaning of the '<em>Type Code</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Type Code</em>' attribute.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind
 	 * @see #setTypeCode(EntryRelationshipKind)
@@ -51,9 +50,7 @@ public interface EntryRelationship extends AssociationValidation {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship#getTypeCode <em>Type Code</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Type Code</em>' attribute.
+	 * @param value the new value of the '<em>Type Code</em>' attribute.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind
 	 * @see #getTypeCode()
 	 * @generated

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/EntryRelationshipKind.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/EntryRelationshipKind.java
@@ -23,7 +23,6 @@ import org.eclipse.emf.common.util.Enumerator;
  * A representation of the literals of the enumeration '<em><b>Entry Relationship Kind</b></em>',
  * and utility methods for working with them.
  * <!-- end-user-doc -->
- * 
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getEntryRelationshipKind()
  * @model
  * @generated
@@ -33,7 +32,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * The '<em><b>CAUS</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #CAUS_VALUE
 	 * @generated
 	 * @ordered
@@ -44,7 +42,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * The '<em><b>COMP</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #COMP_VALUE
 	 * @generated
 	 * @ordered
@@ -55,7 +52,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * The '<em><b>GEVL</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #GEVL_VALUE
 	 * @generated
 	 * @ordered
@@ -66,7 +62,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * The '<em><b>MFST</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #MFST_VALUE
 	 * @generated
 	 * @ordered
@@ -77,7 +72,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * The '<em><b>REFR</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #REFR_VALUE
 	 * @generated
 	 * @ordered
@@ -88,7 +82,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * The '<em><b>RSON</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #RSON_VALUE
 	 * @generated
 	 * @ordered
@@ -99,7 +92,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * The '<em><b>SAS</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #SAS_VALUE
 	 * @generated
 	 * @ordered
@@ -110,7 +102,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * The '<em><b>SPRT</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #SPRT_VALUE
 	 * @generated
 	 * @ordered
@@ -121,7 +112,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * The '<em><b>SUBJ</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #SUBJ_VALUE
 	 * @generated
 	 * @ordered
@@ -132,7 +122,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * The '<em><b>XCRPT</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #XCRPT_VALUE
 	 * @generated
 	 * @ordered
@@ -146,7 +135,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * If the meaning of '<em><b>CAUS</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #CAUS
 	 * @model
 	 * @generated
@@ -161,7 +149,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * If the meaning of '<em><b>COMP</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #COMP
 	 * @model
 	 * @generated
@@ -176,7 +163,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * If the meaning of '<em><b>GEVL</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #GEVL
 	 * @model
 	 * @generated
@@ -191,7 +177,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * If the meaning of '<em><b>MFST</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #MFST
 	 * @model
 	 * @generated
@@ -206,7 +191,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * If the meaning of '<em><b>REFR</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #REFR
 	 * @model
 	 * @generated
@@ -221,7 +205,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * If the meaning of '<em><b>RSON</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #RSON
 	 * @model
 	 * @generated
@@ -236,7 +219,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * If the meaning of '<em><b>SAS</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #SAS
 	 * @model
 	 * @generated
@@ -251,7 +233,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * If the meaning of '<em><b>SPRT</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #SPRT
 	 * @model
 	 * @generated
@@ -266,7 +247,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * If the meaning of '<em><b>SUBJ</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #SUBJ
 	 * @model
 	 * @generated
@@ -281,7 +261,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * If the meaning of '<em><b>XCRPT</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #XCRPT
 	 * @model
 	 * @generated
@@ -293,17 +272,25 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * An array of all the '<em><b>Entry Relationship Kind</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private static final EntryRelationshipKind[] VALUES_ARRAY = new EntryRelationshipKind[] {
-			CAUS, COMP, GEVL, MFST, REFR, RSON, SAS, SPRT, SUBJ, XCRPT, };
+			CAUS,
+			COMP,
+			GEVL,
+			MFST,
+			REFR,
+			RSON,
+			SAS,
+			SPRT,
+			SUBJ,
+			XCRPT,
+		};
 
 	/**
 	 * A public read-only list of all the '<em><b>Entry Relationship Kind</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static final List<EntryRelationshipKind> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
@@ -312,31 +299,20 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * Returns the '<em><b>Entry Relationship Kind</b></em>' literal with the specified integer value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static EntryRelationshipKind get(int value) {
 		switch (value) {
-			case CAUS_VALUE:
-				return CAUS;
-			case COMP_VALUE:
-				return COMP;
-			case GEVL_VALUE:
-				return GEVL;
-			case MFST_VALUE:
-				return MFST;
-			case REFR_VALUE:
-				return REFR;
-			case RSON_VALUE:
-				return RSON;
-			case SAS_VALUE:
-				return SAS;
-			case SPRT_VALUE:
-				return SPRT;
-			case SUBJ_VALUE:
-				return SUBJ;
-			case XCRPT_VALUE:
-				return XCRPT;
+			case CAUS_VALUE: return CAUS;
+			case COMP_VALUE: return COMP;
+			case GEVL_VALUE: return GEVL;
+			case MFST_VALUE: return MFST;
+			case REFR_VALUE: return REFR;
+			case RSON_VALUE: return RSON;
+			case SAS_VALUE: return SAS;
+			case SPRT_VALUE: return SPRT;
+			case SUBJ_VALUE: return SUBJ;
+			case XCRPT_VALUE: return XCRPT;
 		}
 		return null;
 	}
@@ -345,7 +321,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * Returns the '<em><b>Entry Relationship Kind</b></em>' literal with the specified literal value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static EntryRelationshipKind get(String literal) {
@@ -362,7 +337,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * Returns the '<em><b>Entry Relationship Kind</b></em>' literal with the specified name.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static EntryRelationshipKind getByName(String name) {
@@ -378,7 +352,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final int value;
@@ -386,7 +359,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final String name;
@@ -394,7 +366,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final String literal;
@@ -403,7 +374,6 @@ public enum EntryRelationshipKind implements Enumerator {
 	 * Only this class can construct instances.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EntryRelationshipKind(int value, String name, String literal) {
@@ -415,38 +385,34 @@ public enum EntryRelationshipKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
-		return literal;
+	  return literal;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getName() {
-		return name;
+	  return name;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public int getValue() {
-		return value;
+	  return value;
 	}
 
 	/**
 	 * Returns the literal value of the enumerator, which is its string representation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/Inline.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/Inline.java
@@ -8,16 +8,16 @@ import org.eclipse.emf.ecore.EObject;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Inline</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#getBase_Class <em>Base Class</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#getFilter <em>Filter</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#isPublishSeperately <em>Publish Seperately</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#getBase_Class <em>Base Class</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#getFilter <em>Filter</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#isPublishSeperately <em>Publish Seperately</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getInline()
  * @model
  * @generated
@@ -30,7 +30,6 @@ public interface Inline extends EObject {
 	 * If the meaning of the '<em>Base Class</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Base Class</em>' reference.
 	 * @see #setBase_Class(org.eclipse.uml2.uml.Class)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getInline_Base_Class()
@@ -43,9 +42,7 @@ public interface Inline extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#getBase_Class <em>Base Class</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Base Class</em>' reference.
+	 * @param value the new value of the '<em>Base Class</em>' reference.
 	 * @see #getBase_Class()
 	 * @generated
 	 */
@@ -58,7 +55,6 @@ public interface Inline extends EObject {
 	 * If the meaning of the '<em>Filter</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Filter</em>' attribute.
 	 * @see #setFilter(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getInline_Filter()
@@ -71,9 +67,7 @@ public interface Inline extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#getFilter <em>Filter</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Filter</em>' attribute.
+	 * @param value the new value of the '<em>Filter</em>' attribute.
 	 * @see #getFilter()
 	 * @generated
 	 */
@@ -86,7 +80,6 @@ public interface Inline extends EObject {
 	 * If the meaning of the '<em>Publish Seperately</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Publish Seperately</em>' attribute.
 	 * @see #setPublishSeperately(boolean)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getInline_PublishSeperately()
@@ -99,9 +92,7 @@ public interface Inline extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Inline#isPublishSeperately <em>Publish Seperately</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Publish Seperately</em>' attribute.
+	 * @param value the new value of the '<em>Publish Seperately</em>' attribute.
 	 * @see #isPublishSeperately()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/LogicalConstraint.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/LogicalConstraint.java
@@ -6,14 +6,14 @@ package org.openhealthtools.mdht.uml.cda.core.profile;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Logical Constraint</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.LogicalConstraint#getOperation <em>Operation</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.LogicalConstraint#getOperation <em>Operation</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getLogicalConstraint()
  * @model
  * @generated
@@ -27,7 +27,6 @@ public interface LogicalConstraint extends ConstraintValidation {
 	 * If the meaning of the '<em>Operation</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Operation</em>' attribute.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.LogicalOperator
 	 * @see #setOperation(LogicalOperator)
@@ -41,9 +40,7 @@ public interface LogicalConstraint extends ConstraintValidation {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.LogicalConstraint#getOperation <em>Operation</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Operation</em>' attribute.
+	 * @param value the new value of the '<em>Operation</em>' attribute.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.LogicalOperator
 	 * @see #getOperation()
 	 * @generated

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/LogicalOperator.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/LogicalOperator.java
@@ -13,7 +13,6 @@ import org.eclipse.emf.common.util.Enumerator;
  * A representation of the literals of the enumeration '<em><b>Logical Operator</b></em>',
  * and utility methods for working with them.
  * <!-- end-user-doc -->
- * 
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getLogicalOperator()
  * @model
  * @generated
@@ -23,7 +22,6 @@ public enum LogicalOperator implements Enumerator {
 	 * The '<em><b>AND</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #AND_VALUE
 	 * @generated
 	 * @ordered
@@ -34,7 +32,6 @@ public enum LogicalOperator implements Enumerator {
 	 * The '<em><b>OR</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #OR_VALUE
 	 * @generated
 	 * @ordered
@@ -45,7 +42,6 @@ public enum LogicalOperator implements Enumerator {
 	 * The '<em><b>XOR</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #XOR_VALUE
 	 * @generated
 	 * @ordered
@@ -56,7 +52,6 @@ public enum LogicalOperator implements Enumerator {
 	 * The '<em><b>IFTHEN</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #IFTHEN_VALUE
 	 * @generated
 	 * @ordered
@@ -67,7 +62,6 @@ public enum LogicalOperator implements Enumerator {
 	 * The '<em><b>NOTBOTH</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #NOTBOTH_VALUE
 	 * @generated
 	 * @ordered
@@ -81,7 +75,6 @@ public enum LogicalOperator implements Enumerator {
 	 * If the meaning of '<em><b>AND</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #AND
 	 * @model
 	 * @generated
@@ -96,7 +89,6 @@ public enum LogicalOperator implements Enumerator {
 	 * If the meaning of '<em><b>OR</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #OR
 	 * @model
 	 * @generated
@@ -111,7 +103,6 @@ public enum LogicalOperator implements Enumerator {
 	 * If the meaning of '<em><b>XOR</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #XOR
 	 * @model
 	 * @generated
@@ -126,7 +117,6 @@ public enum LogicalOperator implements Enumerator {
 	 * If the meaning of '<em><b>IFTHEN</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #IFTHEN
 	 * @model
 	 * @generated
@@ -141,7 +131,6 @@ public enum LogicalOperator implements Enumerator {
 	 * If the meaning of '<em><b>NOTBOTH</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #NOTBOTH
 	 * @model
 	 * @generated
@@ -153,16 +142,20 @@ public enum LogicalOperator implements Enumerator {
 	 * An array of all the '<em><b>Logical Operator</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
-	private static final LogicalOperator[] VALUES_ARRAY = new LogicalOperator[] { AND, OR, XOR, IFTHEN, NOTBOTH, };
+	private static final LogicalOperator[] VALUES_ARRAY = new LogicalOperator[] {
+			AND,
+			OR,
+			XOR,
+			IFTHEN,
+			NOTBOTH,
+		};
 
 	/**
 	 * A public read-only list of all the '<em><b>Logical Operator</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static final List<LogicalOperator> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
@@ -171,7 +164,6 @@ public enum LogicalOperator implements Enumerator {
 	 * Returns the '<em><b>Logical Operator</b></em>' literal with the specified literal value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static LogicalOperator get(String literal) {
@@ -188,7 +180,6 @@ public enum LogicalOperator implements Enumerator {
 	 * Returns the '<em><b>Logical Operator</b></em>' literal with the specified name.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static LogicalOperator getByName(String name) {
@@ -205,21 +196,15 @@ public enum LogicalOperator implements Enumerator {
 	 * Returns the '<em><b>Logical Operator</b></em>' literal with the specified integer value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static LogicalOperator get(int value) {
 		switch (value) {
-			case AND_VALUE:
-				return AND;
-			case OR_VALUE:
-				return OR;
-			case XOR_VALUE:
-				return XOR;
-			case IFTHEN_VALUE:
-				return IFTHEN;
-			case NOTBOTH_VALUE:
-				return NOTBOTH;
+			case AND_VALUE: return AND;
+			case OR_VALUE: return OR;
+			case XOR_VALUE: return XOR;
+			case IFTHEN_VALUE: return IFTHEN;
+			case NOTBOTH_VALUE: return NOTBOTH;
 		}
 		return null;
 	}
@@ -227,7 +212,6 @@ public enum LogicalOperator implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final int value;
@@ -235,7 +219,6 @@ public enum LogicalOperator implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final String name;
@@ -243,7 +226,6 @@ public enum LogicalOperator implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final String literal;
@@ -252,7 +234,6 @@ public enum LogicalOperator implements Enumerator {
 	 * Only this class can construct instances.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private LogicalOperator(int value, String name, String literal) {
@@ -264,38 +245,34 @@ public enum LogicalOperator implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public int getValue() {
-		return value;
+	  return value;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getName() {
-		return name;
+	  return name;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
-		return literal;
+	  return literal;
 	}
 
 	/**
 	 * Returns the literal value of the enumerator, which is its string representation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/NullFlavor.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/NullFlavor.java
@@ -16,14 +16,14 @@ package org.openhealthtools.mdht.uml.cda.core.profile;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Null Flavor</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.NullFlavor#getNullFlavor <em>Null Flavor</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.NullFlavor#getNullFlavor <em>Null Flavor</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getNullFlavor()
  * @model
  * @generated
@@ -37,7 +37,6 @@ public interface NullFlavor extends PropertyValidation {
 	 * If the meaning of the '<em>Null Flavor</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Null Flavor</em>' attribute.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.NullFlavorKind
 	 * @see #setNullFlavor(NullFlavorKind)
@@ -51,9 +50,7 @@ public interface NullFlavor extends PropertyValidation {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.NullFlavor#getNullFlavor <em>Null Flavor</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Null Flavor</em>' attribute.
+	 * @param value the new value of the '<em>Null Flavor</em>' attribute.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.NullFlavorKind
 	 * @see #getNullFlavor()
 	 * @generated

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/NullFlavorKind.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/NullFlavorKind.java
@@ -23,7 +23,6 @@ import org.eclipse.emf.common.util.Enumerator;
  * A representation of the literals of the enumeration '<em><b>Null Flavor Kind</b></em>',
  * and utility methods for working with them.
  * <!-- end-user-doc -->
- * 
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getNullFlavorKind()
  * @model
  * @generated
@@ -33,7 +32,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>ASKU</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #ASKU_VALUE
 	 * @generated
 	 * @ordered
@@ -44,7 +42,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>MSK</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #MSK_VALUE
 	 * @generated
 	 * @ordered
@@ -55,7 +52,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>NA</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #NA_VALUE
 	 * @generated
 	 * @ordered
@@ -66,7 +62,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>NASK</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #NASK_VALUE
 	 * @generated
 	 * @ordered
@@ -77,7 +72,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>NAV</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #NAV_VALUE
 	 * @generated
 	 * @ordered
@@ -88,7 +82,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>NI</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #NI_VALUE
 	 * @generated
 	 * @ordered
@@ -99,7 +92,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>NINF</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #NINF_VALUE
 	 * @generated
 	 * @ordered
@@ -110,7 +102,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>OTH</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #OTH_VALUE
 	 * @generated
 	 * @ordered
@@ -121,7 +112,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>PINF</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #PINF_VALUE
 	 * @generated
 	 * @ordered
@@ -132,7 +122,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>QS</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #QS_VALUE
 	 * @generated
 	 * @ordered
@@ -143,7 +132,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>TRC</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #TRC_VALUE
 	 * @generated
 	 * @ordered
@@ -154,7 +142,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>UNC</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #UNC_VALUE
 	 * @generated
 	 * @ordered
@@ -165,7 +152,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * The '<em><b>UNK</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #UNK_VALUE
 	 * @generated
 	 * @ordered
@@ -179,7 +165,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>ASKU</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #ASKU
 	 * @model
 	 * @generated
@@ -194,7 +179,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>MSK</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #MSK
 	 * @model
 	 * @generated
@@ -209,7 +193,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>NA</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #NA
 	 * @model
 	 * @generated
@@ -224,7 +207,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>NASK</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #NASK
 	 * @model
 	 * @generated
@@ -239,7 +221,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>NAV</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #NAV
 	 * @model
 	 * @generated
@@ -254,7 +235,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>NI</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #NI
 	 * @model
 	 * @generated
@@ -269,7 +249,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>NINF</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #NINF
 	 * @model
 	 * @generated
@@ -284,7 +263,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>OTH</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #OTH
 	 * @model
 	 * @generated
@@ -299,7 +277,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>PINF</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #PINF
 	 * @model
 	 * @generated
@@ -314,7 +291,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>QS</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #QS
 	 * @model
 	 * @generated
@@ -329,7 +305,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>TRC</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #TRC
 	 * @model
 	 * @generated
@@ -344,7 +319,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>UNC</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #UNC
 	 * @model
 	 * @generated
@@ -359,7 +333,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * If the meaning of '<em><b>UNK</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #UNK
 	 * @model
 	 * @generated
@@ -371,17 +344,28 @@ public enum NullFlavorKind implements Enumerator {
 	 * An array of all the '<em><b>Null Flavor Kind</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private static final NullFlavorKind[] VALUES_ARRAY = new NullFlavorKind[] {
-			ASKU, MSK, NA, NASK, NAV, NI, NINF, OTH, PINF, QS, TRC, UNC, UNK, };
+			ASKU,
+			MSK,
+			NA,
+			NASK,
+			NAV,
+			NI,
+			NINF,
+			OTH,
+			PINF,
+			QS,
+			TRC,
+			UNC,
+			UNK,
+		};
 
 	/**
 	 * A public read-only list of all the '<em><b>Null Flavor Kind</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static final List<NullFlavorKind> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
@@ -390,37 +374,23 @@ public enum NullFlavorKind implements Enumerator {
 	 * Returns the '<em><b>Null Flavor Kind</b></em>' literal with the specified integer value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static NullFlavorKind get(int value) {
 		switch (value) {
-			case ASKU_VALUE:
-				return ASKU;
-			case MSK_VALUE:
-				return MSK;
-			case NA_VALUE:
-				return NA;
-			case NASK_VALUE:
-				return NASK;
-			case NAV_VALUE:
-				return NAV;
-			case NI_VALUE:
-				return NI;
-			case NINF_VALUE:
-				return NINF;
-			case OTH_VALUE:
-				return OTH;
-			case PINF_VALUE:
-				return PINF;
-			case QS_VALUE:
-				return QS;
-			case TRC_VALUE:
-				return TRC;
-			case UNC_VALUE:
-				return UNC;
-			case UNK_VALUE:
-				return UNK;
+			case ASKU_VALUE: return ASKU;
+			case MSK_VALUE: return MSK;
+			case NA_VALUE: return NA;
+			case NASK_VALUE: return NASK;
+			case NAV_VALUE: return NAV;
+			case NI_VALUE: return NI;
+			case NINF_VALUE: return NINF;
+			case OTH_VALUE: return OTH;
+			case PINF_VALUE: return PINF;
+			case QS_VALUE: return QS;
+			case TRC_VALUE: return TRC;
+			case UNC_VALUE: return UNC;
+			case UNK_VALUE: return UNK;
 		}
 		return null;
 	}
@@ -429,7 +399,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * Returns the '<em><b>Null Flavor Kind</b></em>' literal with the specified literal value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static NullFlavorKind get(String literal) {
@@ -446,7 +415,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * Returns the '<em><b>Null Flavor Kind</b></em>' literal with the specified name.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static NullFlavorKind getByName(String name) {
@@ -462,7 +430,6 @@ public enum NullFlavorKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final int value;
@@ -470,7 +437,6 @@ public enum NullFlavorKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final String name;
@@ -478,7 +444,6 @@ public enum NullFlavorKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final String literal;
@@ -487,7 +452,6 @@ public enum NullFlavorKind implements Enumerator {
 	 * Only this class can construct instances.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private NullFlavorKind(int value, String name, String literal) {
@@ -499,38 +463,34 @@ public enum NullFlavorKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
-		return literal;
+	  return literal;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getName() {
-		return name;
+	  return name;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public int getValue() {
-		return value;
+	  return value;
 	}
 
 	/**
 	 * Returns the literal value of the enumerator, which is its string representation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/Participation.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/Participation.java
@@ -20,16 +20,16 @@ import org.eclipse.uml2.uml.EnumerationLiteral;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Participation</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getBase_Association <em>Base Association</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getAssociationType <em>Association Type</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getTypeCode <em>Type Code</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getBase_Association <em>Base Association</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getAssociationType <em>Association Type</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getTypeCode <em>Type Code</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getParticipation()
  * @model
  * @generated
@@ -42,7 +42,6 @@ public interface Participation extends EObject {
 	 * If the meaning of the '<em>Association Type</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Association Type</em>' reference.
 	 * @see #setAssociationType(org.eclipse.uml2.uml.Class)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getParticipation_AssociationType()
@@ -58,7 +57,6 @@ public interface Participation extends EObject {
 	 * If the meaning of the '<em>Base Association</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Base Association</em>' reference.
 	 * @see #setBase_Association(Association)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getParticipation_Base_Association()
@@ -74,7 +72,6 @@ public interface Participation extends EObject {
 	 * If the meaning of the '<em>Type Code</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Type Code</em>' reference.
 	 * @see #setTypeCode(EnumerationLiteral)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getParticipation_TypeCode()
@@ -84,26 +81,20 @@ public interface Participation extends EObject {
 	EnumerationLiteral getTypeCode();
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getAssociationType <em>Association Type</em>}'
-	 * reference.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getAssociationType <em>Association Type</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Association Type</em>' reference.
+	 * @param value the new value of the '<em>Association Type</em>' reference.
 	 * @see #getAssociationType()
 	 * @generated
 	 */
 	void setAssociationType(org.eclipse.uml2.uml.Class value);
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getBase_Association <em>Base Association</em>}'
-	 * reference.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getBase_Association <em>Base Association</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Base Association</em>' reference.
+	 * @param value the new value of the '<em>Base Association</em>' reference.
 	 * @see #getBase_Association()
 	 * @generated
 	 */
@@ -113,9 +104,7 @@ public interface Participation extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Participation#getTypeCode <em>Type Code</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Type Code</em>' reference.
+	 * @param value the new value of the '<em>Type Code</em>' reference.
 	 * @see #getTypeCode()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/PropertyValidation.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/PropertyValidation.java
@@ -18,14 +18,14 @@ import org.eclipse.uml2.uml.Property;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Property Validation</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation#getBase_Property <em>Base Property</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation#getBase_Property <em>Base Property</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getPropertyValidation()
  * @model
  * @generated
@@ -38,7 +38,6 @@ public interface PropertyValidation extends Validation {
 	 * If the meaning of the '<em>Base Property</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Base Property</em>' reference.
 	 * @see #setBase_Property(Property)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getPropertyValidation_Base_Property()
@@ -48,13 +47,10 @@ public interface PropertyValidation extends Validation {
 	Property getBase_Property();
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation#getBase_Property <em>Base Property</em>}'
-	 * reference.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation#getBase_Property <em>Base Property</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Base Property</em>' reference.
+	 * @param value the new value of the '<em>Base Property</em>' reference.
 	 * @see #getBase_Property()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/SeverityKind.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/SeverityKind.java
@@ -23,7 +23,6 @@ import org.eclipse.emf.common.util.Enumerator;
  * A representation of the literals of the enumeration '<em><b>Severity Kind</b></em>',
  * and utility methods for working with them.
  * <!-- end-user-doc -->
- * 
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getSeverityKind()
  * @model
  * @generated
@@ -33,7 +32,6 @@ public enum SeverityKind implements Enumerator {
 	 * The '<em><b>ERROR</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #ERROR_VALUE
 	 * @generated
 	 * @ordered
@@ -44,7 +42,6 @@ public enum SeverityKind implements Enumerator {
 	 * The '<em><b>WARNING</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #WARNING_VALUE
 	 * @generated
 	 * @ordered
@@ -55,7 +52,6 @@ public enum SeverityKind implements Enumerator {
 	 * The '<em><b>INFO</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #INFO_VALUE
 	 * @generated
 	 * @ordered
@@ -69,7 +65,6 @@ public enum SeverityKind implements Enumerator {
 	 * If the meaning of '<em><b>ERROR</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #ERROR
 	 * @model
 	 * @generated
@@ -84,7 +79,6 @@ public enum SeverityKind implements Enumerator {
 	 * If the meaning of '<em><b>WARNING</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #WARNING
 	 * @model
 	 * @generated
@@ -99,7 +93,6 @@ public enum SeverityKind implements Enumerator {
 	 * If the meaning of '<em><b>INFO</b></em>' literal object isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #INFO
 	 * @model
 	 * @generated
@@ -111,16 +104,18 @@ public enum SeverityKind implements Enumerator {
 	 * An array of all the '<em><b>Severity Kind</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
-	private static final SeverityKind[] VALUES_ARRAY = new SeverityKind[] { ERROR, WARNING, INFO, };
+	private static final SeverityKind[] VALUES_ARRAY = new SeverityKind[] {
+			ERROR,
+			WARNING,
+			INFO,
+		};
 
 	/**
 	 * A public read-only list of all the '<em><b>Severity Kind</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static final List<SeverityKind> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
@@ -129,17 +124,13 @@ public enum SeverityKind implements Enumerator {
 	 * Returns the '<em><b>Severity Kind</b></em>' literal with the specified integer value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static SeverityKind get(int value) {
 		switch (value) {
-			case ERROR_VALUE:
-				return ERROR;
-			case WARNING_VALUE:
-				return WARNING;
-			case INFO_VALUE:
-				return INFO;
+			case ERROR_VALUE: return ERROR;
+			case WARNING_VALUE: return WARNING;
+			case INFO_VALUE: return INFO;
 		}
 		return null;
 	}
@@ -148,7 +139,6 @@ public enum SeverityKind implements Enumerator {
 	 * Returns the '<em><b>Severity Kind</b></em>' literal with the specified literal value.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static SeverityKind get(String literal) {
@@ -165,7 +155,6 @@ public enum SeverityKind implements Enumerator {
 	 * Returns the '<em><b>Severity Kind</b></em>' literal with the specified name.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static SeverityKind getByName(String name) {
@@ -181,7 +170,6 @@ public enum SeverityKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final int value;
@@ -189,7 +177,6 @@ public enum SeverityKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final String name;
@@ -197,7 +184,6 @@ public enum SeverityKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private final String literal;
@@ -206,7 +192,6 @@ public enum SeverityKind implements Enumerator {
 	 * Only this class can construct instances.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private SeverityKind(int value, String name, String literal) {
@@ -218,38 +203,34 @@ public enum SeverityKind implements Enumerator {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
-		return literal;
+	  return literal;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getName() {
-		return name;
+	  return name;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public int getValue() {
-		return value;
+	  return value;
 	}
 
 	/**
 	 * Returns the literal value of the enumerator, which is its string representation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/TextValue.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/TextValue.java
@@ -16,15 +16,15 @@ package org.openhealthtools.mdht.uml.cda.core.profile;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Text Value</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.TextValue#getValue <em>Value</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.TextValue#isIgnoreCase <em>Ignore Case</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.TextValue#getValue <em>Value</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.TextValue#isIgnoreCase <em>Ignore Case</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getTextValue()
  * @model
  * @generated
@@ -37,7 +37,6 @@ public interface TextValue extends PropertyValidation {
 	 * If the meaning of the '<em>Value</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Value</em>' attribute.
 	 * @see #setValue(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getTextValue_Value()
@@ -54,7 +53,6 @@ public interface TextValue extends PropertyValidation {
 	 * If the meaning of the '<em>Ignore Case</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Ignore Case</em>' attribute.
 	 * @see #setIgnoreCase(boolean)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getTextValue_IgnoreCase()
@@ -67,9 +65,7 @@ public interface TextValue extends PropertyValidation {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.TextValue#isIgnoreCase <em>Ignore Case</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Ignore Case</em>' attribute.
+	 * @param value the new value of the '<em>Ignore Case</em>' attribute.
 	 * @see #isIgnoreCase()
 	 * @generated
 	 */
@@ -79,9 +75,7 @@ public interface TextValue extends PropertyValidation {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.TextValue#getValue <em>Value</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Value</em>' attribute.
+	 * @param value the new value of the '<em>Value</em>' attribute.
 	 * @see #getValue()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/Unimplementable.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/Unimplementable.java
@@ -10,14 +10,14 @@ import org.eclipse.uml2.uml.Constraint;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Unimplementable</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Unimplementable#getBase_Constraint <em>Base Constraint</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Unimplementable#getBase_Constraint <em>Base Constraint</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getUnimplementable()
  * @model
  * @generated
@@ -30,7 +30,6 @@ public interface Unimplementable extends EObject {
 	 * If the meaning of the '<em>Base Constraint</em>' reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Base Constraint</em>' reference.
 	 * @see #setBase_Constraint(Constraint)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getUnimplementable_Base_Constraint()
@@ -40,13 +39,10 @@ public interface Unimplementable extends EObject {
 	Constraint getBase_Constraint();
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Unimplementable#getBase_Constraint <em>Base Constraint</em>}'
-	 * reference.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Unimplementable#getBase_Constraint <em>Base Constraint</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Base Constraint</em>' reference.
+	 * @param value the new value of the '<em>Base Constraint</em>' reference.
 	 * @see #getBase_Constraint()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/Validation.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/Validation.java
@@ -19,17 +19,17 @@ import org.eclipse.emf.ecore.EObject;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Validation</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#getMessage <em>Message</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#getSeverity <em>Severity</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#getRuleId <em>Rule Id</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#isMandatory <em>Mandatory</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#getMessage <em>Message</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#getSeverity <em>Severity</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#getRuleId <em>Rule Id</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#isMandatory <em>Mandatory</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getValidation()
  * @model abstract="true"
  * @generated
@@ -42,7 +42,6 @@ public interface Validation extends EObject {
 	 * If the meaning of the '<em>Message</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Message</em>' attribute.
 	 * @see #setMessage(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getValidation_Message()
@@ -59,7 +58,6 @@ public interface Validation extends EObject {
 	 * If the meaning of the '<em>Rule Id</em>' attribute list isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Rule Id</em>' attribute list.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getValidation_RuleId()
 	 * @model dataType="org.eclipse.uml2.types.String" ordered="false"
@@ -75,7 +73,6 @@ public interface Validation extends EObject {
 	 * If the meaning of the '<em>Severity</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Severity</em>' attribute.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.SeverityKind
 	 * @see #setSeverity(SeverityKind)
@@ -93,7 +90,6 @@ public interface Validation extends EObject {
 	 * If the meaning of the '<em>Mandatory</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Mandatory</em>' attribute.
 	 * @see #setMandatory(boolean)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getValidation_Mandatory()
@@ -106,9 +102,7 @@ public interface Validation extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#isMandatory <em>Mandatory</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Mandatory</em>' attribute.
+	 * @param value the new value of the '<em>Mandatory</em>' attribute.
 	 * @see #isMandatory()
 	 * @generated
 	 */
@@ -118,9 +112,7 @@ public interface Validation extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#getMessage <em>Message</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Message</em>' attribute.
+	 * @param value the new value of the '<em>Message</em>' attribute.
 	 * @see #getMessage()
 	 * @generated
 	 */
@@ -130,9 +122,7 @@ public interface Validation extends EObject {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.Validation#getSeverity <em>Severity</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Severity</em>' attribute.
+	 * @param value the new value of the '<em>Severity</em>' attribute.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.SeverityKind
 	 * @see #getSeverity()
 	 * @generated

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/ValueSetConstraint.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/ValueSetConstraint.java
@@ -16,8 +16,8 @@ package org.openhealthtools.mdht.uml.cda.core.profile;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Value Set Constraint</b></em>'.
  * <!-- end-user-doc -->
- * 
- * 
+ *
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getValueSetConstraint()
  * @model
  * @generated

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/VocabSpecification.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/VocabSpecification.java
@@ -16,18 +16,18 @@ package org.openhealthtools.mdht.uml.cda.core.profile;
  * <!-- begin-user-doc -->
  * A representation of the model object '<em><b>Vocab Specification</b></em>'.
  * <!-- end-user-doc -->
- * 
+ *
  * <p>
  * The following features are supported:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCode <em>Code</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystem <em>Code System</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemName <em>Code System Name</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemVersion <em>Code System Version</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getDisplayName <em>Display Name</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCode <em>Code</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystem <em>Code System</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemName <em>Code System Name</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemVersion <em>Code System Version</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getDisplayName <em>Display Name</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getVocabSpecification()
  * @model
  * @generated
@@ -40,7 +40,6 @@ public interface VocabSpecification extends PropertyValidation {
 	 * If the meaning of the '<em>Code</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Code</em>' attribute.
 	 * @see #setCode(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getVocabSpecification_Code()
@@ -56,7 +55,6 @@ public interface VocabSpecification extends PropertyValidation {
 	 * If the meaning of the '<em>Code System</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Code System</em>' attribute.
 	 * @see #setCodeSystem(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getVocabSpecification_CodeSystem()
@@ -72,7 +70,6 @@ public interface VocabSpecification extends PropertyValidation {
 	 * If the meaning of the '<em>Code System Name</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Code System Name</em>' attribute.
 	 * @see #setCodeSystemName(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getVocabSpecification_CodeSystemName()
@@ -88,7 +85,6 @@ public interface VocabSpecification extends PropertyValidation {
 	 * If the meaning of the '<em>Code System Version</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Code System Version</em>' attribute.
 	 * @see #setCodeSystemVersion(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getVocabSpecification_CodeSystemVersion()
@@ -104,7 +100,6 @@ public interface VocabSpecification extends PropertyValidation {
 	 * If the meaning of the '<em>Display Name</em>' attribute isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the value of the '<em>Display Name</em>' attribute.
 	 * @see #setDisplayName(String)
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#getVocabSpecification_DisplayName()
@@ -117,9 +112,7 @@ public interface VocabSpecification extends PropertyValidation {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCode <em>Code</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Code</em>' attribute.
+	 * @param value the new value of the '<em>Code</em>' attribute.
 	 * @see #getCode()
 	 * @generated
 	 */
@@ -129,48 +122,37 @@ public interface VocabSpecification extends PropertyValidation {
 	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystem <em>Code System</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Code System</em>' attribute.
+	 * @param value the new value of the '<em>Code System</em>' attribute.
 	 * @see #getCodeSystem()
 	 * @generated
 	 */
 	void setCodeSystem(String value);
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemName <em>Code System Name</em>}'
-	 * attribute.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemName <em>Code System Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Code System Name</em>' attribute.
+	 * @param value the new value of the '<em>Code System Name</em>' attribute.
 	 * @see #getCodeSystemName()
 	 * @generated
 	 */
 	void setCodeSystemName(String value);
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemVersion
-	 * <em>Code System Version</em>}' attribute.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getCodeSystemVersion <em>Code System Version</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Code System Version</em>' attribute.
+	 * @param value the new value of the '<em>Code System Version</em>' attribute.
 	 * @see #getCodeSystemVersion()
 	 * @generated
 	 */
 	void setCodeSystemVersion(String value);
 
 	/**
-	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getDisplayName <em>Display Name</em>}'
-	 * attribute.
+	 * Sets the value of the '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification#getDisplayName <em>Display Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param value
-	 *            the new value of the '<em>Display Name</em>' attribute.
+	 * @param value the new value of the '<em>Display Name</em>' attribute.
 	 * @see #getDisplayName()
 	 * @generated
 	 */

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ActRelationshipImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ActRelationshipImpl.java
@@ -29,12 +29,12 @@ import org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ActRelationshipImpl#getBase_Association <em>Base Association</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ActRelationshipImpl#getAssociationType <em>Association Type</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ActRelationshipImpl#getTypeCode <em>Type Code</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ActRelationshipImpl#getBase_Association <em>Base Association</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ActRelationshipImpl#getAssociationType <em>Association Type</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ActRelationshipImpl#getTypeCode <em>Type Code</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ActRelationshipImpl extends EObjectImpl implements ActRelationship {
@@ -42,7 +42,6 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	 * The cached value of the '{@link #getBase_Association() <em>Base Association</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getBase_Association()
 	 * @generated
 	 * @ordered
@@ -53,7 +52,6 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	 * The cached value of the '{@link #getAssociationType() <em>Association Type</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getAssociationType()
 	 * @generated
 	 * @ordered
@@ -64,7 +62,6 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	 * The cached value of the '{@link #getTypeCode() <em>Type Code</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getTypeCode()
 	 * @generated
 	 * @ordered
@@ -74,7 +71,6 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected ActRelationshipImpl() {
@@ -84,7 +80,6 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public org.eclipse.uml2.uml.Class basicGetAssociationType() {
@@ -94,7 +89,6 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Association basicGetBase_Association() {
@@ -104,7 +98,6 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EnumerationLiteral basicGetTypeCode() {
@@ -114,26 +107,19 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
 			case CDAPackage.ACT_RELATIONSHIP__BASE_ASSOCIATION:
-				if (resolve) {
-					return getBase_Association();
-				}
+				if (resolve) return getBase_Association();
 				return basicGetBase_Association();
 			case CDAPackage.ACT_RELATIONSHIP__ASSOCIATION_TYPE:
-				if (resolve) {
-					return getAssociationType();
-				}
+				if (resolve) return getAssociationType();
 				return basicGetAssociationType();
 			case CDAPackage.ACT_RELATIONSHIP__TYPE_CODE:
-				if (resolve) {
-					return getTypeCode();
-				}
+				if (resolve) return getTypeCode();
 				return basicGetTypeCode();
 		}
 		return super.eGet(featureID, resolve, coreType);
@@ -142,7 +128,6 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -161,20 +146,19 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.ACT_RELATIONSHIP__BASE_ASSOCIATION:
-				setBase_Association((Association) newValue);
+				setBase_Association((Association)newValue);
 				return;
 			case CDAPackage.ACT_RELATIONSHIP__ASSOCIATION_TYPE:
-				setAssociationType((org.eclipse.uml2.uml.Class) newValue);
+				setAssociationType((org.eclipse.uml2.uml.Class)newValue);
 				return;
 			case CDAPackage.ACT_RELATIONSHIP__TYPE_CODE:
-				setTypeCode((EnumerationLiteral) newValue);
+				setTypeCode((EnumerationLiteral)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -183,7 +167,6 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -194,20 +177,19 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
 			case CDAPackage.ACT_RELATIONSHIP__BASE_ASSOCIATION:
-				setBase_Association((Association) null);
+				setBase_Association((Association)null);
 				return;
 			case CDAPackage.ACT_RELATIONSHIP__ASSOCIATION_TYPE:
-				setAssociationType((org.eclipse.uml2.uml.Class) null);
+				setAssociationType((org.eclipse.uml2.uml.Class)null);
 				return;
 			case CDAPackage.ACT_RELATIONSHIP__TYPE_CODE:
-				setTypeCode((EnumerationLiteral) null);
+				setTypeCode((EnumerationLiteral)null);
 				return;
 		}
 		super.eUnset(featureID);
@@ -216,19 +198,15 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public org.eclipse.uml2.uml.Class getAssociationType() {
 		if (associationType != null && associationType.eIsProxy()) {
-			InternalEObject oldAssociationType = (InternalEObject) associationType;
-			associationType = (org.eclipse.uml2.uml.Class) eResolveProxy(oldAssociationType);
+			InternalEObject oldAssociationType = (InternalEObject)associationType;
+			associationType = (org.eclipse.uml2.uml.Class)eResolveProxy(oldAssociationType);
 			if (associationType != oldAssociationType) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.ACT_RELATIONSHIP__ASSOCIATION_TYPE, oldAssociationType,
-						associationType));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.ACT_RELATIONSHIP__ASSOCIATION_TYPE, oldAssociationType, associationType));
 			}
 		}
 		return associationType;
@@ -237,19 +215,15 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Association getBase_Association() {
 		if (base_Association != null && base_Association.eIsProxy()) {
-			InternalEObject oldBase_Association = (InternalEObject) base_Association;
-			base_Association = (Association) eResolveProxy(oldBase_Association);
+			InternalEObject oldBase_Association = (InternalEObject)base_Association;
+			base_Association = (Association)eResolveProxy(oldBase_Association);
 			if (base_Association != oldBase_Association) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.ACT_RELATIONSHIP__BASE_ASSOCIATION, oldBase_Association,
-						base_Association));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.ACT_RELATIONSHIP__BASE_ASSOCIATION, oldBase_Association, base_Association));
 			}
 		}
 		return base_Association;
@@ -258,18 +232,15 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EnumerationLiteral getTypeCode() {
 		if (typeCode != null && typeCode.eIsProxy()) {
-			InternalEObject oldTypeCode = (InternalEObject) typeCode;
-			typeCode = (EnumerationLiteral) eResolveProxy(oldTypeCode);
+			InternalEObject oldTypeCode = (InternalEObject)typeCode;
+			typeCode = (EnumerationLiteral)eResolveProxy(oldTypeCode);
 			if (typeCode != oldTypeCode) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.ACT_RELATIONSHIP__TYPE_CODE, oldTypeCode, typeCode));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.ACT_RELATIONSHIP__TYPE_CODE, oldTypeCode, typeCode));
 			}
 		}
 		return typeCode;
@@ -278,48 +249,37 @@ public class ActRelationshipImpl extends EObjectImpl implements ActRelationship 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setAssociationType(org.eclipse.uml2.uml.Class newAssociationType) {
 		org.eclipse.uml2.uml.Class oldAssociationType = associationType;
 		associationType = newAssociationType;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.ACT_RELATIONSHIP__ASSOCIATION_TYPE, oldAssociationType,
-				associationType));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.ACT_RELATIONSHIP__ASSOCIATION_TYPE, oldAssociationType, associationType));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setBase_Association(Association newBase_Association) {
 		Association oldBase_Association = base_Association;
 		base_Association = newBase_Association;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.ACT_RELATIONSHIP__BASE_ASSOCIATION, oldBase_Association,
-				base_Association));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.ACT_RELATIONSHIP__BASE_ASSOCIATION, oldBase_Association, base_Association));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setTypeCode(EnumerationLiteral newTypeCode) {
 		EnumerationLiteral oldTypeCode = typeCode;
 		typeCode = newTypeCode;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.ACT_RELATIONSHIP__TYPE_CODE, oldTypeCode, typeCode));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.ACT_RELATIONSHIP__TYPE_CODE, oldTypeCode, typeCode));
 	}
 
 } // ActRelationshipImpl

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/AssociationValidationImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/AssociationValidationImpl.java
@@ -27,10 +27,10 @@ import org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.AssociationValidationImpl#getBase_Association <em>Base Association</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.AssociationValidationImpl#getBase_Association <em>Base Association</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class AssociationValidationImpl extends ValidationImpl implements AssociationValidation {
@@ -38,7 +38,6 @@ public class AssociationValidationImpl extends ValidationImpl implements Associa
 	 * The cached value of the '{@link #getBase_Association() <em>Base Association</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getBase_Association()
 	 * @generated
 	 * @ordered
@@ -48,7 +47,6 @@ public class AssociationValidationImpl extends ValidationImpl implements Associa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected AssociationValidationImpl() {
@@ -58,7 +56,6 @@ public class AssociationValidationImpl extends ValidationImpl implements Associa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Association basicGetBase_Association() {
@@ -68,16 +65,13 @@ public class AssociationValidationImpl extends ValidationImpl implements Associa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
 			case CDAPackage.ASSOCIATION_VALIDATION__BASE_ASSOCIATION:
-				if (resolve) {
-					return getBase_Association();
-				}
+				if (resolve) return getBase_Association();
 				return basicGetBase_Association();
 		}
 		return super.eGet(featureID, resolve, coreType);
@@ -86,7 +80,6 @@ public class AssociationValidationImpl extends ValidationImpl implements Associa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -101,14 +94,13 @@ public class AssociationValidationImpl extends ValidationImpl implements Associa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.ASSOCIATION_VALIDATION__BASE_ASSOCIATION:
-				setBase_Association((Association) newValue);
+				setBase_Association((Association)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -117,7 +109,6 @@ public class AssociationValidationImpl extends ValidationImpl implements Associa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -128,14 +119,13 @@ public class AssociationValidationImpl extends ValidationImpl implements Associa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
 			case CDAPackage.ASSOCIATION_VALIDATION__BASE_ASSOCIATION:
-				setBase_Association((Association) null);
+				setBase_Association((Association)null);
 				return;
 		}
 		super.eUnset(featureID);
@@ -144,19 +134,15 @@ public class AssociationValidationImpl extends ValidationImpl implements Associa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Association getBase_Association() {
 		if (base_Association != null && base_Association.eIsProxy()) {
-			InternalEObject oldBase_Association = (InternalEObject) base_Association;
-			base_Association = (Association) eResolveProxy(oldBase_Association);
+			InternalEObject oldBase_Association = (InternalEObject)base_Association;
+			base_Association = (Association)eResolveProxy(oldBase_Association);
 			if (base_Association != oldBase_Association) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.ASSOCIATION_VALIDATION__BASE_ASSOCIATION,
-						oldBase_Association, base_Association));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.ASSOCIATION_VALIDATION__BASE_ASSOCIATION, oldBase_Association, base_Association));
 			}
 		}
 		return base_Association;
@@ -165,17 +151,13 @@ public class AssociationValidationImpl extends ValidationImpl implements Associa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setBase_Association(Association newBase_Association) {
 		Association oldBase_Association = base_Association;
 		base_Association = newBase_Association;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.ASSOCIATION_VALIDATION__BASE_ASSOCIATION, oldBase_Association,
-				base_Association));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.ASSOCIATION_VALIDATION__BASE_ASSOCIATION, oldBase_Association, base_Association));
 	}
 
 } // AssociationValidationImpl

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/CDAFactoryImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/CDAFactoryImpl.java
@@ -47,14 +47,12 @@ import org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification;
  * <!-- begin-user-doc -->
  * An implementation of the model <b>Factory</b>.
  * <!-- end-user-doc -->
- * 
  * @generated
  */
 public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @deprecated
 	 * @generated
 	 */
@@ -67,16 +65,16 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	 * Creates the default factory implementation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public static CDAFactory init() {
 		try {
-			CDAFactory theCDAFactory = (CDAFactory) EPackage.Registry.INSTANCE.getEFactory(CDAPackage.eNS_URI);
+			CDAFactory theCDAFactory = (CDAFactory)EPackage.Registry.INSTANCE.getEFactory(CDAPackage.eNS_URI);
 			if (theCDAFactory != null) {
 				return theCDAFactory;
 			}
-		} catch (Exception exception) {
+		}
+		catch (Exception exception) {
 			EcorePlugin.INSTANCE.log(exception);
 		}
 		return new CDAFactoryImpl();
@@ -86,7 +84,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	 * Creates an instance of the factory.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public CDAFactoryImpl() {
@@ -96,82 +93,62 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String convertEntryKindToString(EDataType eDataType, Object instanceValue) {
-		return instanceValue == null
-				? null
-				: instanceValue.toString();
+		return instanceValue == null ? null : instanceValue.toString();
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String convertEntryRelationshipKindToString(EDataType eDataType, Object instanceValue) {
-		return instanceValue == null
-				? null
-				: instanceValue.toString();
+		return instanceValue == null ? null : instanceValue.toString();
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String convertNullFlavorKindToString(EDataType eDataType, Object instanceValue) {
-		return instanceValue == null
-				? null
-				: instanceValue.toString();
+		return instanceValue == null ? null : instanceValue.toString();
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public LogicalOperator createLogicalOperatorFromString(EDataType eDataType, String initialValue) {
 		LogicalOperator result = LogicalOperator.get(initialValue);
-		if (result == null) {
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" +
-					eDataType.getName() + "'");
-		}
+		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String convertLogicalOperatorToString(EDataType eDataType, Object instanceValue) {
-		return instanceValue == null
-				? null
-				: instanceValue.toString();
+		return instanceValue == null ? null : instanceValue.toString();
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String convertSeverityKindToString(EDataType eDataType, Object instanceValue) {
-		return instanceValue == null
-				? null
-				: instanceValue.toString();
+		return instanceValue == null ? null : instanceValue.toString();
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -188,60 +165,38 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 			case CDAPackage.LOGICAL_OPERATOR:
 				return convertLogicalOperatorToString(eDataType, instanceValue);
 			default:
-				throw new IllegalArgumentException("The datatype '" + eDataType.getName() +
-						"' is not a valid classifier");
+				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public EObject create(EClass eClass) {
 		switch (eClass.getClassifierID()) {
-			case CDAPackage.ENTRY:
-				return createEntry();
-			case CDAPackage.ASSOCIATION_VALIDATION:
-				return createAssociationValidation();
-			case CDAPackage.ENTRY_RELATIONSHIP:
-				return createEntryRelationship();
-			case CDAPackage.CODEGEN_SUPPORT:
-				return createCodegenSupport();
-			case CDAPackage.PROPERTY_VALIDATION:
-				return createPropertyValidation();
-			case CDAPackage.CLASS_VALIDATION:
-				return createClassValidation();
-			case CDAPackage.VOCAB_SPECIFICATION:
-				return createVocabSpecification();
-			case CDAPackage.NULL_FLAVOR:
-				return createNullFlavor();
-			case CDAPackage.TEXT_VALUE:
-				return createTextValue();
-			case CDAPackage.CDA_TEMPLATE:
-				return createCDATemplate();
-			case CDAPackage.CONSTRAINT_VALIDATION:
-				return createConstraintValidation();
-			case CDAPackage.CONFORMS_TO:
-				return createConformsTo();
-			case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT:
-				return createConceptDomainConstraint();
-			case CDAPackage.CODE_SYSTEM_CONSTRAINT:
-				return createCodeSystemConstraint();
-			case CDAPackage.VALUE_SET_CONSTRAINT:
-				return createValueSetConstraint();
-			case CDAPackage.ACT_RELATIONSHIP:
-				return createActRelationship();
-			case CDAPackage.PARTICIPATION:
-				return createParticipation();
-			case CDAPackage.LOGICAL_CONSTRAINT:
-				return createLogicalConstraint();
-			case CDAPackage.INLINE:
-				return createInline();
-			case CDAPackage.UNIMPLEMENTABLE:
-				return createUnimplementable();
+			case CDAPackage.ENTRY: return createEntry();
+			case CDAPackage.ASSOCIATION_VALIDATION: return createAssociationValidation();
+			case CDAPackage.ENTRY_RELATIONSHIP: return createEntryRelationship();
+			case CDAPackage.CODEGEN_SUPPORT: return createCodegenSupport();
+			case CDAPackage.PROPERTY_VALIDATION: return createPropertyValidation();
+			case CDAPackage.CLASS_VALIDATION: return createClassValidation();
+			case CDAPackage.VOCAB_SPECIFICATION: return createVocabSpecification();
+			case CDAPackage.NULL_FLAVOR: return createNullFlavor();
+			case CDAPackage.TEXT_VALUE: return createTextValue();
+			case CDAPackage.CDA_TEMPLATE: return createCDATemplate();
+			case CDAPackage.CONSTRAINT_VALIDATION: return createConstraintValidation();
+			case CDAPackage.CONFORMS_TO: return createConformsTo();
+			case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT: return createConceptDomainConstraint();
+			case CDAPackage.CODE_SYSTEM_CONSTRAINT: return createCodeSystemConstraint();
+			case CDAPackage.VALUE_SET_CONSTRAINT: return createValueSetConstraint();
+			case CDAPackage.ACT_RELATIONSHIP: return createActRelationship();
+			case CDAPackage.PARTICIPATION: return createParticipation();
+			case CDAPackage.LOGICAL_CONSTRAINT: return createLogicalConstraint();
+			case CDAPackage.INLINE: return createInline();
+			case CDAPackage.UNIMPLEMENTABLE: return createUnimplementable();
 			default:
 				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
 		}
@@ -250,7 +205,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public ActRelationship createActRelationship() {
@@ -261,7 +215,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public AssociationValidation createAssociationValidation() {
@@ -272,7 +225,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public CDATemplate createCDATemplate() {
@@ -283,7 +235,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public ClassValidation createClassValidation() {
@@ -294,7 +245,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public CodegenSupport createCodegenSupport() {
@@ -305,7 +255,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public CodeSystemConstraint createCodeSystemConstraint() {
@@ -316,7 +265,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public ConceptDomainConstraint createConceptDomainConstraint() {
@@ -327,7 +275,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public ConformsTo createConformsTo() {
@@ -338,7 +285,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public ConstraintValidation createConstraintValidation() {
@@ -349,7 +295,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Entry createEntry() {
@@ -360,22 +305,17 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EntryKind createEntryKindFromString(EDataType eDataType, String initialValue) {
 		EntryKind result = EntryKind.get(initialValue);
-		if (result == null) {
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" +
-					eDataType.getName() + "'");
-		}
+		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EntryRelationship createEntryRelationship() {
@@ -386,22 +326,17 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EntryRelationshipKind createEntryRelationshipKindFromString(EDataType eDataType, String initialValue) {
 		EntryRelationshipKind result = EntryRelationshipKind.get(initialValue);
-		if (result == null) {
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" +
-					eDataType.getName() + "'");
-		}
+		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -418,15 +353,13 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 			case CDAPackage.LOGICAL_OPERATOR:
 				return createLogicalOperatorFromString(eDataType, initialValue);
 			default:
-				throw new IllegalArgumentException("The datatype '" + eDataType.getName() +
-						"' is not a valid classifier");
+				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
 		}
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public NullFlavor createNullFlavor() {
@@ -437,22 +370,17 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public NullFlavorKind createNullFlavorKindFromString(EDataType eDataType, String initialValue) {
 		NullFlavorKind result = NullFlavorKind.get(initialValue);
-		if (result == null) {
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" +
-					eDataType.getName() + "'");
-		}
+		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Participation createParticipation() {
@@ -463,7 +391,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public LogicalConstraint createLogicalConstraint() {
@@ -474,7 +401,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Inline createInline() {
@@ -485,7 +411,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Unimplementable createUnimplementable() {
@@ -496,7 +421,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public PropertyValidation createPropertyValidation() {
@@ -507,22 +431,17 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public SeverityKind createSeverityKindFromString(EDataType eDataType, String initialValue) {
 		SeverityKind result = SeverityKind.get(initialValue);
-		if (result == null) {
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" +
-					eDataType.getName() + "'");
-		}
+		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public TextValue createTextValue() {
@@ -533,7 +452,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public ValueSetConstraint createValueSetConstraint() {
@@ -544,7 +462,6 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public VocabSpecification createVocabSpecification() {
@@ -555,11 +472,10 @@ public class CDAFactoryImpl extends EFactoryImpl implements CDAFactory {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public CDAPackage getCDAPackage() {
-		return (CDAPackage) getEPackage();
+		return (CDAPackage)getEPackage();
 	}
 
 } // CDAFactoryImpl

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/CDAPackageImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/CDAPackageImpl.java
@@ -54,14 +54,12 @@ import org.openhealthtools.mdht.uml.term.core.profile.TermPackage;
  * <!-- begin-user-doc -->
  * An implementation of the model <b>Package</b>.
  * <!-- end-user-doc -->
- * 
  * @generated
  */
 public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass entryEClass = null;
@@ -69,7 +67,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass associationValidationEClass = null;
@@ -77,7 +74,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass validationEClass = null;
@@ -85,7 +81,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass entryRelationshipEClass = null;
@@ -93,7 +88,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass codegenSupportEClass = null;
@@ -101,7 +95,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass propertyValidationEClass = null;
@@ -109,7 +102,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass classValidationEClass = null;
@@ -117,7 +109,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass vocabSpecificationEClass = null;
@@ -125,7 +116,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass nullFlavorEClass = null;
@@ -133,7 +123,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass textValueEClass = null;
@@ -141,7 +130,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass cdaTemplateEClass = null;
@@ -149,7 +137,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass constraintValidationEClass = null;
@@ -157,7 +144,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass conformsToEClass = null;
@@ -165,7 +151,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass conceptDomainConstraintEClass = null;
@@ -173,7 +158,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass codeSystemConstraintEClass = null;
@@ -181,7 +165,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass valueSetConstraintEClass = null;
@@ -189,7 +172,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass actRelationshipEClass = null;
@@ -197,7 +179,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass participationEClass = null;
@@ -205,7 +186,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass logicalConstraintEClass = null;
@@ -213,7 +193,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass inlineEClass = null;
@@ -221,7 +200,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EClass unimplementableEClass = null;
@@ -229,7 +207,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EEnum severityKindEEnum = null;
@@ -237,7 +214,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EEnum entryKindEEnum = null;
@@ -245,7 +221,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EEnum entryRelationshipKindEEnum = null;
@@ -253,7 +228,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EEnum nullFlavorKindEEnum = null;
@@ -261,7 +235,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private EEnum logicalOperatorEEnum = null;
@@ -269,7 +242,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private static boolean isInited = false;
@@ -277,24 +249,19 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
 	 * 
-	 * <p>
-	 * This method is used to initialize {@link CDAPackage#eINSTANCE} when that field is accessed. Clients should not invoke it directly. Instead,
-	 * they should simply access that field to obtain the package. <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 * <p>This method is used to initialize {@link CDAPackage#eINSTANCE} when that field is accessed.
+	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see #eNS_URI
 	 * @see #createPackageContents()
 	 * @see #initializePackageContents()
 	 * @generated
 	 */
 	public static CDAPackage init() {
-		if (isInited) {
-			return (CDAPackage) EPackage.Registry.INSTANCE.getEPackage(CDAPackage.eNS_URI);
-		}
+		if (isInited) return (CDAPackage)EPackage.Registry.INSTANCE.getEPackage(CDAPackage.eNS_URI);
 
 		// Obtain or create and register package
-		CDAPackageImpl theCDAPackage = (CDAPackageImpl) (EPackage.Registry.INSTANCE.get(eNS_URI) instanceof CDAPackageImpl
-				? EPackage.Registry.INSTANCE.get(eNS_URI)
-				: new CDAPackageImpl());
+		CDAPackageImpl theCDAPackage = (CDAPackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof CDAPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new CDAPackageImpl());
 
 		isInited = true;
 
@@ -310,6 +277,7 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 		// Mark meta-data to indicate it can't be changed
 		theCDAPackage.freeze();
 
+  
 		// Update the registry and return the package
 		EPackage.Registry.INSTANCE.put(CDAPackage.eNS_URI, theCDAPackage);
 		return theCDAPackage;
@@ -318,7 +286,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private boolean isCreated = false;
@@ -326,19 +293,19 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	private boolean isInitialized = false;
 
 	/**
-	 * Creates an instance of the model <b>Package</b>, registered with {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the
-	 * package
+	 * Creates an instance of the model <b>Package</b>, registered with
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
 	 * package URI value.
-	 * <p>
-	 * Note: the correct way to create the package is via the static factory method {@link #init init()}, which also performs initialization of the
-	 * package, or returns the registered package, if one already exists. <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 * <p>Note: the correct way to create the package is via the static
+	 * factory method {@link #init init()}, which also performs
+	 * initialization of the package, or returns the registered package,
+	 * if one already exists.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @see org.eclipse.emf.ecore.EPackage.Registry
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage#eNS_URI
 	 * @see #init()
@@ -349,17 +316,14 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	}
 
 	/**
-	 * Creates the meta-model objects for the package. This method is
+	 * Creates the meta-model objects for the package.  This method is
 	 * guarded to have no affect on any invocation but its first.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void createPackageContents() {
-		if (isCreated) {
-			return;
-		}
+		if (isCreated) return;
 		isCreated = true;
 
 		// Create classes and their features
@@ -411,6 +375,7 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 		createEAttribute(cdaTemplateEClass, CDA_TEMPLATE__ASSIGNING_AUTHORITY_NAME);
 		createEAttribute(cdaTemplateEClass, CDA_TEMPLATE__CONTEXT_DEPENDENT);
 		createEAttribute(cdaTemplateEClass, CDA_TEMPLATE__TEMPLATE_VERSION);
+		createEAttribute(cdaTemplateEClass, CDA_TEMPLATE__TEMPLATE_MULTIPLICITY);
 
 		constraintValidationEClass = createEClass(CONSTRAINT_VALIDATION);
 		createEReference(constraintValidationEClass, CONSTRAINT_VALIDATION__BASE_CONSTRAINT);
@@ -457,7 +422,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getActRelationship() {
@@ -467,37 +431,33 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getActRelationship_AssociationType() {
-		return (EReference) actRelationshipEClass.getEStructuralFeatures().get(1);
+		return (EReference)actRelationshipEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getActRelationship_Base_Association() {
-		return (EReference) actRelationshipEClass.getEStructuralFeatures().get(0);
+		return (EReference)actRelationshipEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getActRelationship_TypeCode() {
-		return (EReference) actRelationshipEClass.getEStructuralFeatures().get(2);
+		return (EReference)actRelationshipEClass.getEStructuralFeatures().get(2);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getAssociationValidation() {
@@ -507,27 +467,24 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getAssociationValidation_Base_Association() {
-		return (EReference) associationValidationEClass.getEStructuralFeatures().get(0);
+		return (EReference)associationValidationEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public CDAFactory getCDAFactory() {
-		return (CDAFactory) getEFactoryInstance();
+		return (CDAFactory)getEFactoryInstance();
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getCDATemplate() {
@@ -537,47 +494,51 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getCDATemplate_AssigningAuthorityName() {
-		return (EAttribute) cdaTemplateEClass.getEStructuralFeatures().get(1);
+		return (EAttribute)cdaTemplateEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getCDATemplate_ContextDependent() {
-		return (EAttribute) cdaTemplateEClass.getEStructuralFeatures().get(2);
+		return (EAttribute)cdaTemplateEClass.getEStructuralFeatures().get(2);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getCDATemplate_TemplateVersion() {
-		return (EAttribute) cdaTemplateEClass.getEStructuralFeatures().get(3);
+		return (EAttribute)cdaTemplateEClass.getEStructuralFeatures().get(3);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
+	 * @generated
+	 */
+	public EAttribute getCDATemplate_TemplateMultiplicity() {
+		return (EAttribute)cdaTemplateEClass.getEStructuralFeatures().get(4);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @generated
 	 */
 	public EAttribute getCDATemplate_TemplateId() {
-		return (EAttribute) cdaTemplateEClass.getEStructuralFeatures().get(0);
+		return (EAttribute)cdaTemplateEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getClassValidation() {
@@ -587,17 +548,15 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getClassValidation_Base_Class() {
-		return (EReference) classValidationEClass.getEStructuralFeatures().get(0);
+		return (EReference)classValidationEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getCodegenSupport() {
@@ -607,67 +566,60 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getCodegenSupport_Base_Namespace() {
-		return (EReference) codegenSupportEClass.getEStructuralFeatures().get(5);
+		return (EReference)codegenSupportEClass.getEStructuralFeatures().get(5);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getCodegenSupport_BasePackage() {
-		return (EAttribute) codegenSupportEClass.getEStructuralFeatures().get(0);
+		return (EAttribute)codegenSupportEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getCodegenSupport_NsPrefix() {
-		return (EAttribute) codegenSupportEClass.getEStructuralFeatures().get(1);
+		return (EAttribute)codegenSupportEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getCodegenSupport_NsURI() {
-		return (EAttribute) codegenSupportEClass.getEStructuralFeatures().get(2);
+		return (EAttribute)codegenSupportEClass.getEStructuralFeatures().get(2);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getCodegenSupport_PackageName() {
-		return (EAttribute) codegenSupportEClass.getEStructuralFeatures().get(3);
+		return (EAttribute)codegenSupportEClass.getEStructuralFeatures().get(3);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getCodegenSupport_Prefix() {
-		return (EAttribute) codegenSupportEClass.getEStructuralFeatures().get(4);
+		return (EAttribute)codegenSupportEClass.getEStructuralFeatures().get(4);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getCodeSystemConstraint() {
@@ -677,7 +629,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getConceptDomainConstraint() {
@@ -687,7 +638,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getConformsTo() {
@@ -697,27 +647,24 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getConformsTo_Base_Generalization() {
-		return (EReference) conformsToEClass.getEStructuralFeatures().get(0);
+		return (EReference)conformsToEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getConformsTo_RequiresParentId() {
-		return (EAttribute) conformsToEClass.getEStructuralFeatures().get(1);
+		return (EAttribute)conformsToEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getConstraintValidation() {
@@ -727,17 +674,15 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getConstraintValidation_Base_Constraint() {
-		return (EReference) constraintValidationEClass.getEStructuralFeatures().get(0);
+		return (EReference)constraintValidationEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getEntry() {
@@ -747,17 +692,15 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getEntry_TypeCode() {
-		return (EAttribute) entryEClass.getEStructuralFeatures().get(0);
+		return (EAttribute)entryEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EEnum getEntryKind() {
@@ -767,7 +710,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getEntryRelationship() {
@@ -777,17 +719,15 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getEntryRelationship_TypeCode() {
-		return (EAttribute) entryRelationshipEClass.getEStructuralFeatures().get(0);
+		return (EAttribute)entryRelationshipEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EEnum getEntryRelationshipKind() {
@@ -797,7 +737,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getNullFlavor() {
@@ -807,17 +746,15 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getNullFlavor_NullFlavor() {
-		return (EAttribute) nullFlavorEClass.getEStructuralFeatures().get(0);
+		return (EAttribute)nullFlavorEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EEnum getNullFlavorKind() {
@@ -827,7 +764,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EEnum getLogicalOperator() {
@@ -837,7 +773,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getParticipation() {
@@ -847,37 +782,33 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getParticipation_AssociationType() {
-		return (EReference) participationEClass.getEStructuralFeatures().get(1);
+		return (EReference)participationEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getParticipation_Base_Association() {
-		return (EReference) participationEClass.getEStructuralFeatures().get(0);
+		return (EReference)participationEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getParticipation_TypeCode() {
-		return (EReference) participationEClass.getEStructuralFeatures().get(2);
+		return (EReference)participationEClass.getEStructuralFeatures().get(2);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getLogicalConstraint() {
@@ -887,17 +818,15 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getLogicalConstraint_Operation() {
-		return (EAttribute) logicalConstraintEClass.getEStructuralFeatures().get(0);
+		return (EAttribute)logicalConstraintEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getInline() {
@@ -907,37 +836,33 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getInline_Base_Class() {
-		return (EReference) inlineEClass.getEStructuralFeatures().get(0);
+		return (EReference)inlineEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getInline_Filter() {
-		return (EAttribute) inlineEClass.getEStructuralFeatures().get(1);
+		return (EAttribute)inlineEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getInline_PublishSeperately() {
-		return (EAttribute) inlineEClass.getEStructuralFeatures().get(2);
+		return (EAttribute)inlineEClass.getEStructuralFeatures().get(2);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getUnimplementable() {
@@ -947,17 +872,15 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getUnimplementable_Base_Constraint() {
-		return (EReference) unimplementableEClass.getEStructuralFeatures().get(0);
+		return (EReference)unimplementableEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getPropertyValidation() {
@@ -967,17 +890,15 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EReference getPropertyValidation_Base_Property() {
-		return (EReference) propertyValidationEClass.getEStructuralFeatures().get(0);
+		return (EReference)propertyValidationEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EEnum getSeverityKind() {
@@ -987,7 +908,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getTextValue() {
@@ -997,27 +917,24 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getTextValue_IgnoreCase() {
-		return (EAttribute) textValueEClass.getEStructuralFeatures().get(1);
+		return (EAttribute)textValueEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getTextValue_Value() {
-		return (EAttribute) textValueEClass.getEStructuralFeatures().get(0);
+		return (EAttribute)textValueEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getValidation() {
@@ -1027,47 +944,42 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getValidation_Mandatory() {
-		return (EAttribute) validationEClass.getEStructuralFeatures().get(3);
+		return (EAttribute)validationEClass.getEStructuralFeatures().get(3);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getValidation_Message() {
-		return (EAttribute) validationEClass.getEStructuralFeatures().get(0);
+		return (EAttribute)validationEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getValidation_RuleId() {
-		return (EAttribute) validationEClass.getEStructuralFeatures().get(2);
+		return (EAttribute)validationEClass.getEStructuralFeatures().get(2);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getValidation_Severity() {
-		return (EAttribute) validationEClass.getEStructuralFeatures().get(1);
+		return (EAttribute)validationEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getValueSetConstraint() {
@@ -1077,7 +989,6 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EClass getVocabSpecification() {
@@ -1087,65 +998,57 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getVocabSpecification_Code() {
-		return (EAttribute) vocabSpecificationEClass.getEStructuralFeatures().get(0);
+		return (EAttribute)vocabSpecificationEClass.getEStructuralFeatures().get(0);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getVocabSpecification_CodeSystem() {
-		return (EAttribute) vocabSpecificationEClass.getEStructuralFeatures().get(1);
+		return (EAttribute)vocabSpecificationEClass.getEStructuralFeatures().get(1);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getVocabSpecification_CodeSystemName() {
-		return (EAttribute) vocabSpecificationEClass.getEStructuralFeatures().get(2);
+		return (EAttribute)vocabSpecificationEClass.getEStructuralFeatures().get(2);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getVocabSpecification_CodeSystemVersion() {
-		return (EAttribute) vocabSpecificationEClass.getEStructuralFeatures().get(3);
+		return (EAttribute)vocabSpecificationEClass.getEStructuralFeatures().get(3);
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EAttribute getVocabSpecification_DisplayName() {
-		return (EAttribute) vocabSpecificationEClass.getEStructuralFeatures().get(4);
+		return (EAttribute)vocabSpecificationEClass.getEStructuralFeatures().get(4);
 	}
 
 	/**
-	 * Complete the initialization of the package and its meta-model. This
+	 * Complete the initialization of the package and its meta-model.  This
 	 * method is guarded to have no affect on any invocation but its first.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void initializePackageContents() {
-		if (isInitialized) {
-			return;
-		}
+		if (isInitialized) return;
 		isInitialized = true;
 
 		// Initialize package
@@ -1154,9 +1057,9 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 		setNsURI(eNS_URI);
 
 		// Obtain other dependent packages
-		UMLPackage theUMLPackage = (UMLPackage) EPackage.Registry.INSTANCE.getEPackage(UMLPackage.eNS_URI);
-		TypesPackage theTypesPackage = (TypesPackage) EPackage.Registry.INSTANCE.getEPackage(TypesPackage.eNS_URI);
-		TermPackage theTermPackage = (TermPackage) EPackage.Registry.INSTANCE.getEPackage(TermPackage.eNS_URI);
+		UMLPackage theUMLPackage = (UMLPackage)EPackage.Registry.INSTANCE.getEPackage(UMLPackage.eNS_URI);
+		TypesPackage theTypesPackage = (TypesPackage)EPackage.Registry.INSTANCE.getEPackage(TypesPackage.eNS_URI);
+		TermPackage theTermPackage = (TermPackage)EPackage.Registry.INSTANCE.getEPackage(TermPackage.eNS_URI);
 
 		// Create type parameters
 
@@ -1184,229 +1087,88 @@ public class CDAPackageImpl extends EPackageImpl implements CDAPackage {
 
 		// Initialize classes and features; add operations and parameters
 		initEClass(entryEClass, Entry.class, "Entry", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(
-			getEntry_TypeCode(), this.getEntryKind(), "typeCode", null, 0, 1, Entry.class, !IS_TRANSIENT, !IS_VOLATILE,
-			IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getEntry_TypeCode(), this.getEntryKind(), "typeCode", null, 0, 1, Entry.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			associationValidationEClass, AssociationValidation.class, "AssociationValidation", !IS_ABSTRACT,
-			!IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(
-			getAssociationValidation_Base_Association(), theUMLPackage.getAssociation(), null, "base_Association",
-			null, 1, 1, AssociationValidation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
-			IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEClass(associationValidationEClass, AssociationValidation.class, "AssociationValidation", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getAssociationValidation_Base_Association(), theUMLPackage.getAssociation(), null, "base_Association", null, 1, 1, AssociationValidation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			validationEClass, Validation.class, "Validation", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(
-			getValidation_Message(), theTypesPackage.getString(), "message", null, 0, 1, Validation.class,
-			!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getValidation_Severity(), this.getSeverityKind(), "severity", null, 0, 1, Validation.class, !IS_TRANSIENT,
-			!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getValidation_RuleId(), theTypesPackage.getString(), "ruleId", null, 0, -1, Validation.class,
-			!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getValidation_Mandatory(), theTypesPackage.getBoolean(), "mandatory", "false", 0, 1, Validation.class,
-			!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEClass(validationEClass, Validation.class, "Validation", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getValidation_Message(), theTypesPackage.getString(), "message", null, 0, 1, Validation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getValidation_Severity(), this.getSeverityKind(), "severity", null, 0, 1, Validation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getValidation_RuleId(), theTypesPackage.getString(), "ruleId", null, 0, -1, Validation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getValidation_Mandatory(), theTypesPackage.getBoolean(), "mandatory", "false", 0, 1, Validation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			entryRelationshipEClass, EntryRelationship.class, "EntryRelationship", !IS_ABSTRACT, !IS_INTERFACE,
-			IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(
-			getEntryRelationship_TypeCode(), this.getEntryRelationshipKind(), "typeCode", null, 0, 1,
-			EntryRelationship.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
+		initEClass(entryRelationshipEClass, EntryRelationship.class, "EntryRelationship", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getEntryRelationship_TypeCode(), this.getEntryRelationshipKind(), "typeCode", null, 0, 1, EntryRelationship.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			codegenSupportEClass, CodegenSupport.class, "CodegenSupport", !IS_ABSTRACT, !IS_INTERFACE,
-			IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(
-			getCodegenSupport_BasePackage(), theTypesPackage.getString(), "basePackage", null, 0, 1,
-			CodegenSupport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getCodegenSupport_NsPrefix(), theTypesPackage.getString(), "nsPrefix", null, 0, 1, CodegenSupport.class,
-			!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getCodegenSupport_NsURI(), theTypesPackage.getString(), "nsURI", null, 0, 1, CodegenSupport.class,
-			!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getCodegenSupport_PackageName(), theTypesPackage.getString(), "packageName", null, 0, 1,
-			CodegenSupport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getCodegenSupport_Prefix(), theTypesPackage.getString(), "prefix", null, 0, 1, CodegenSupport.class,
-			!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(
-			getCodegenSupport_Base_Namespace(), theUMLPackage.getNamespace(), null, "base_Namespace", null, 1, 1,
-			CodegenSupport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
-			!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEClass(codegenSupportEClass, CodegenSupport.class, "CodegenSupport", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getCodegenSupport_BasePackage(), theTypesPackage.getString(), "basePackage", null, 0, 1, CodegenSupport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getCodegenSupport_NsPrefix(), theTypesPackage.getString(), "nsPrefix", null, 0, 1, CodegenSupport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getCodegenSupport_NsURI(), theTypesPackage.getString(), "nsURI", null, 0, 1, CodegenSupport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getCodegenSupport_PackageName(), theTypesPackage.getString(), "packageName", null, 0, 1, CodegenSupport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getCodegenSupport_Prefix(), theTypesPackage.getString(), "prefix", null, 0, 1, CodegenSupport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEReference(getCodegenSupport_Base_Namespace(), theUMLPackage.getNamespace(), null, "base_Namespace", null, 1, 1, CodegenSupport.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			propertyValidationEClass, PropertyValidation.class, "PropertyValidation", !IS_ABSTRACT, !IS_INTERFACE,
-			IS_GENERATED_INSTANCE_CLASS);
-		initEReference(
-			getPropertyValidation_Base_Property(), theUMLPackage.getProperty(), null, "base_Property", null, 1, 1,
-			PropertyValidation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
-			!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEClass(propertyValidationEClass, PropertyValidation.class, "PropertyValidation", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getPropertyValidation_Base_Property(), theUMLPackage.getProperty(), null, "base_Property", null, 1, 1, PropertyValidation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			classValidationEClass, ClassValidation.class, "ClassValidation", !IS_ABSTRACT, !IS_INTERFACE,
-			IS_GENERATED_INSTANCE_CLASS);
-		initEReference(
-			getClassValidation_Base_Class(), theUMLPackage.getClass_(), null, "base_Class", null, 1, 1,
-			ClassValidation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
-			!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEClass(classValidationEClass, ClassValidation.class, "ClassValidation", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getClassValidation_Base_Class(), theUMLPackage.getClass_(), null, "base_Class", null, 1, 1, ClassValidation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			vocabSpecificationEClass, VocabSpecification.class, "VocabSpecification", !IS_ABSTRACT, !IS_INTERFACE,
-			IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(
-			getVocabSpecification_Code(), theTypesPackage.getString(), "code", null, 0, 1, VocabSpecification.class,
-			!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getVocabSpecification_CodeSystem(), theTypesPackage.getString(), "codeSystem", null, 0, 1,
-			VocabSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getVocabSpecification_CodeSystemName(), theTypesPackage.getString(), "codeSystemName", null, 0, 1,
-			VocabSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getVocabSpecification_CodeSystemVersion(), theTypesPackage.getString(), "codeSystemVersion", null, 0, 1,
-			VocabSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getVocabSpecification_DisplayName(), theTypesPackage.getString(), "displayName", null, 0, 1,
-			VocabSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
+		initEClass(vocabSpecificationEClass, VocabSpecification.class, "VocabSpecification", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getVocabSpecification_Code(), theTypesPackage.getString(), "code", null, 0, 1, VocabSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getVocabSpecification_CodeSystem(), theTypesPackage.getString(), "codeSystem", null, 0, 1, VocabSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getVocabSpecification_CodeSystemName(), theTypesPackage.getString(), "codeSystemName", null, 0, 1, VocabSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getVocabSpecification_CodeSystemVersion(), theTypesPackage.getString(), "codeSystemVersion", null, 0, 1, VocabSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getVocabSpecification_DisplayName(), theTypesPackage.getString(), "displayName", null, 0, 1, VocabSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			nullFlavorEClass, NullFlavor.class, "NullFlavor", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(
-			getNullFlavor_NullFlavor(), this.getNullFlavorKind(), "nullFlavor", null, 0, 1, NullFlavor.class,
-			!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEClass(nullFlavorEClass, NullFlavor.class, "NullFlavor", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getNullFlavor_NullFlavor(), this.getNullFlavorKind(), "nullFlavor", null, 0, 1, NullFlavor.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			textValueEClass, TextValue.class, "TextValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(
-			getTextValue_Value(), theTypesPackage.getString(), "value", null, 0, 1, TextValue.class, !IS_TRANSIENT,
-			!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getTextValue_IgnoreCase(), theTypesPackage.getBoolean(), "ignoreCase", "false", 0, 1, TextValue.class,
-			!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEClass(textValueEClass, TextValue.class, "TextValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getTextValue_Value(), theTypesPackage.getString(), "value", null, 0, 1, TextValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getTextValue_IgnoreCase(), theTypesPackage.getBoolean(), "ignoreCase", "false", 0, 1, TextValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			cdaTemplateEClass, CDATemplate.class, "CDATemplate", !IS_ABSTRACT, !IS_INTERFACE,
-			IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(
-			getCDATemplate_TemplateId(), theTypesPackage.getString(), "templateId", null, 0, 1, CDATemplate.class,
-			!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getCDATemplate_AssigningAuthorityName(), theTypesPackage.getString(), "assigningAuthorityName", null, 0, 1,
-			CDATemplate.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getCDATemplate_ContextDependent(), theTypesPackage.getBoolean(), "contextDependent", "false", 0, 1,
-			CDATemplate.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getCDATemplate_TemplateVersion(), theTypesPackage.getString(), "templateVersion", null, 0, 1,
-			CDATemplate.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
+		initEClass(cdaTemplateEClass, CDATemplate.class, "CDATemplate", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getCDATemplate_TemplateId(), theTypesPackage.getString(), "templateId", null, 0, 1, CDATemplate.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getCDATemplate_AssigningAuthorityName(), theTypesPackage.getString(), "assigningAuthorityName", null, 0, 1, CDATemplate.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getCDATemplate_ContextDependent(), theTypesPackage.getBoolean(), "contextDependent", "false", 0, 1, CDATemplate.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getCDATemplate_TemplateVersion(), theTypesPackage.getString(), "templateVersion", null, 0, 1, CDATemplate.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getCDATemplate_TemplateMultiplicity(), theTypesPackage.getString(), "templateMultiplicity", null, 0, 1, CDATemplate.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			constraintValidationEClass, ConstraintValidation.class, "ConstraintValidation", !IS_ABSTRACT,
-			!IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(
-			getConstraintValidation_Base_Constraint(), theUMLPackage.getConstraint(), null, "base_Constraint", null, 1,
-			1, ConstraintValidation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
-			IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEClass(constraintValidationEClass, ConstraintValidation.class, "ConstraintValidation", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getConstraintValidation_Base_Constraint(), theUMLPackage.getConstraint(), null, "base_Constraint", null, 1, 1, ConstraintValidation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			conformsToEClass, ConformsTo.class, "ConformsTo", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(
-			getConformsTo_Base_Generalization(), theUMLPackage.getGeneralization(), null, "base_Generalization", null,
-			1, 1, ConformsTo.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
-			!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getConformsTo_RequiresParentId(), theTypesPackage.getBoolean(), "requiresParentId", "false", 0, 1,
-			ConformsTo.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
+		initEClass(conformsToEClass, ConformsTo.class, "ConformsTo", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getConformsTo_Base_Generalization(), theUMLPackage.getGeneralization(), null, "base_Generalization", null, 1, 1, ConformsTo.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getConformsTo_RequiresParentId(), theTypesPackage.getBoolean(), "requiresParentId", "false", 0, 1, ConformsTo.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			conceptDomainConstraintEClass, ConceptDomainConstraint.class, "ConceptDomainConstraint", !IS_ABSTRACT,
-			!IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(conceptDomainConstraintEClass, ConceptDomainConstraint.class, "ConceptDomainConstraint", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
-		initEClass(
-			codeSystemConstraintEClass, CodeSystemConstraint.class, "CodeSystemConstraint", !IS_ABSTRACT,
-			!IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(codeSystemConstraintEClass, CodeSystemConstraint.class, "CodeSystemConstraint", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
-		initEClass(
-			valueSetConstraintEClass, ValueSetConstraint.class, "ValueSetConstraint", !IS_ABSTRACT, !IS_INTERFACE,
-			IS_GENERATED_INSTANCE_CLASS);
+		initEClass(valueSetConstraintEClass, ValueSetConstraint.class, "ValueSetConstraint", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
-		initEClass(
-			actRelationshipEClass, ActRelationship.class, "ActRelationship", !IS_ABSTRACT, !IS_INTERFACE,
-			IS_GENERATED_INSTANCE_CLASS);
-		initEReference(
-			getActRelationship_Base_Association(), theUMLPackage.getAssociation(), null, "base_Association", null, 1,
-			1, ActRelationship.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
-			!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(
-			getActRelationship_AssociationType(), theUMLPackage.getClass_(), null, "associationType", null, 0, 1,
-			ActRelationship.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
-			!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(
-			getActRelationship_TypeCode(), theUMLPackage.getEnumerationLiteral(), null, "typeCode", null, 0, 1,
-			ActRelationship.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
-			!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEClass(actRelationshipEClass, ActRelationship.class, "ActRelationship", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getActRelationship_Base_Association(), theUMLPackage.getAssociation(), null, "base_Association", null, 1, 1, ActRelationship.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEReference(getActRelationship_AssociationType(), theUMLPackage.getClass_(), null, "associationType", null, 0, 1, ActRelationship.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEReference(getActRelationship_TypeCode(), theUMLPackage.getEnumerationLiteral(), null, "typeCode", null, 0, 1, ActRelationship.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			participationEClass, Participation.class, "Participation", !IS_ABSTRACT, !IS_INTERFACE,
-			IS_GENERATED_INSTANCE_CLASS);
-		initEReference(
-			getParticipation_Base_Association(), theUMLPackage.getAssociation(), null, "base_Association", null, 1, 1,
-			Participation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
-			!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(
-			getParticipation_AssociationType(), theUMLPackage.getClass_(), null, "associationType", null, 0, 1,
-			Participation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
-			!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(
-			getParticipation_TypeCode(), theUMLPackage.getEnumerationLiteral(), null, "typeCode", null, 0, 1,
-			Participation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
-			!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEClass(participationEClass, Participation.class, "Participation", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getParticipation_Base_Association(), theUMLPackage.getAssociation(), null, "base_Association", null, 1, 1, Participation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEReference(getParticipation_AssociationType(), theUMLPackage.getClass_(), null, "associationType", null, 0, 1, Participation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEReference(getParticipation_TypeCode(), theUMLPackage.getEnumerationLiteral(), null, "typeCode", null, 0, 1, Participation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			logicalConstraintEClass, LogicalConstraint.class, "LogicalConstraint", !IS_ABSTRACT, !IS_INTERFACE,
-			IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(
-			getLogicalConstraint_Operation(), this.getLogicalOperator(), "operation", null, 1, 1,
-			LogicalConstraint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
+		initEClass(logicalConstraintEClass, LogicalConstraint.class, "LogicalConstraint", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getLogicalConstraint_Operation(), this.getLogicalOperator(), "operation", null, 1, 1, LogicalConstraint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
 		initEClass(inlineEClass, Inline.class, "Inline", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(
-			getInline_Base_Class(), theUMLPackage.getClass_(), null, "base_Class", null, 1, 1, Inline.class,
-			!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE,
-			!IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getInline_Filter(), theTypesPackage.getString(), "filter", null, 0, 1, Inline.class, !IS_TRANSIENT,
-			!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEAttribute(
-			getInline_PublishSeperately(), theTypesPackage.getBoolean(), "publishSeperately", null, 0, 1, Inline.class,
-			!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEReference(getInline_Base_Class(), theUMLPackage.getClass_(), null, "base_Class", null, 1, 1, Inline.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getInline_Filter(), theTypesPackage.getString(), "filter", null, 0, 1, Inline.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEAttribute(getInline_PublishSeperately(), theTypesPackage.getBoolean(), "publishSeperately", null, 0, 1, Inline.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(
-			unimplementableEClass, Unimplementable.class, "Unimplementable", !IS_ABSTRACT, !IS_INTERFACE,
-			IS_GENERATED_INSTANCE_CLASS);
-		initEReference(
-			getUnimplementable_Base_Constraint(), theUMLPackage.getConstraint(), null, "base_Constraint", null, 1, 1,
-			Unimplementable.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
-			!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEClass(unimplementableEClass, Unimplementable.class, "Unimplementable", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getUnimplementable_Base_Constraint(), theUMLPackage.getConstraint(), null, "base_Constraint", null, 1, 1, Unimplementable.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
 		// Initialize enums and add enum literals
 		initEEnum(severityKindEEnum, SeverityKind.class, "SeverityKind");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/CDATemplateImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/CDATemplateImpl.java
@@ -25,13 +25,14 @@ import org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl#getTemplateId <em>Template Id</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl#getAssigningAuthorityName <em>Assigning Authority Name</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl#isContextDependent <em>Context Dependent</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl#getTemplateVersion <em>Template Version</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl#getTemplateId <em>Template Id</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl#getAssigningAuthorityName <em>Assigning Authority Name</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl#isContextDependent <em>Context Dependent</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl#getTemplateVersion <em>Template Version</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CDATemplateImpl#getTemplateMultiplicity <em>Template Multiplicity</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate {
@@ -39,7 +40,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	 * The default value of the '{@link #getTemplateId() <em>Template Id</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getTemplateId()
 	 * @generated
 	 * @ordered
@@ -50,7 +50,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	 * The cached value of the '{@link #getTemplateId() <em>Template Id</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getTemplateId()
 	 * @generated
 	 * @ordered
@@ -61,7 +60,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	 * The default value of the '{@link #getAssigningAuthorityName() <em>Assigning Authority Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getAssigningAuthorityName()
 	 * @generated
 	 * @ordered
@@ -72,7 +70,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	 * The cached value of the '{@link #getAssigningAuthorityName() <em>Assigning Authority Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getAssigningAuthorityName()
 	 * @generated
 	 * @ordered
@@ -83,7 +80,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	 * The default value of the '{@link #isContextDependent() <em>Context Dependent</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isContextDependent()
 	 * @generated
 	 * @ordered
@@ -94,7 +90,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	 * The cached value of the '{@link #isContextDependent() <em>Context Dependent</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isContextDependent()
 	 * @generated
 	 * @ordered
@@ -105,7 +100,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	 * The default value of the '{@link #getTemplateVersion() <em>Template Version</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getTemplateVersion()
 	 * @generated
 	 * @ordered
@@ -116,7 +110,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	 * The cached value of the '{@link #getTemplateVersion() <em>Template Version</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getTemplateVersion()
 	 * @generated
 	 * @ordered
@@ -124,9 +117,28 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	protected String templateVersion = TEMPLATE_VERSION_EDEFAULT;
 
 	/**
+	 * The default value of the '{@link #getTemplateMultiplicity() <em>Template Multiplicity</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
+	 * @see #getTemplateMultiplicity()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String TEMPLATE_MULTIPLICITY_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getTemplateMultiplicity() <em>Template Multiplicity</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getTemplateMultiplicity()
+	 * @generated
+	 * @ordered
+	 */
+	protected String templateMultiplicity = TEMPLATE_MULTIPLICITY_EDEFAULT;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @generated
 	 */
 	protected CDATemplateImpl() {
@@ -136,7 +148,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -150,6 +161,8 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 				return isContextDependent();
 			case CDAPackage.CDA_TEMPLATE__TEMPLATE_VERSION:
 				return getTemplateVersion();
+			case CDAPackage.CDA_TEMPLATE__TEMPLATE_MULTIPLICITY:
+				return getTemplateMultiplicity();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -157,26 +170,21 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
 			case CDAPackage.CDA_TEMPLATE__TEMPLATE_ID:
-				return TEMPLATE_ID_EDEFAULT == null
-						? templateId != null
-						: !TEMPLATE_ID_EDEFAULT.equals(templateId);
+				return TEMPLATE_ID_EDEFAULT == null ? templateId != null : !TEMPLATE_ID_EDEFAULT.equals(templateId);
 			case CDAPackage.CDA_TEMPLATE__ASSIGNING_AUTHORITY_NAME:
-				return ASSIGNING_AUTHORITY_NAME_EDEFAULT == null
-						? assigningAuthorityName != null
-						: !ASSIGNING_AUTHORITY_NAME_EDEFAULT.equals(assigningAuthorityName);
+				return ASSIGNING_AUTHORITY_NAME_EDEFAULT == null ? assigningAuthorityName != null : !ASSIGNING_AUTHORITY_NAME_EDEFAULT.equals(assigningAuthorityName);
 			case CDAPackage.CDA_TEMPLATE__CONTEXT_DEPENDENT:
 				return contextDependent != CONTEXT_DEPENDENT_EDEFAULT;
 			case CDAPackage.CDA_TEMPLATE__TEMPLATE_VERSION:
-				return TEMPLATE_VERSION_EDEFAULT == null
-						? templateVersion != null
-						: !TEMPLATE_VERSION_EDEFAULT.equals(templateVersion);
+				return TEMPLATE_VERSION_EDEFAULT == null ? templateVersion != null : !TEMPLATE_VERSION_EDEFAULT.equals(templateVersion);
+			case CDAPackage.CDA_TEMPLATE__TEMPLATE_MULTIPLICITY:
+				return TEMPLATE_MULTIPLICITY_EDEFAULT == null ? templateMultiplicity != null : !TEMPLATE_MULTIPLICITY_EDEFAULT.equals(templateMultiplicity);
 		}
 		return super.eIsSet(featureID);
 	}
@@ -184,23 +192,25 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.CDA_TEMPLATE__TEMPLATE_ID:
-				setTemplateId((String) newValue);
+				setTemplateId((String)newValue);
 				return;
 			case CDAPackage.CDA_TEMPLATE__ASSIGNING_AUTHORITY_NAME:
-				setAssigningAuthorityName((String) newValue);
+				setAssigningAuthorityName((String)newValue);
 				return;
 			case CDAPackage.CDA_TEMPLATE__CONTEXT_DEPENDENT:
-				setContextDependent((Boolean) newValue);
+				setContextDependent((Boolean)newValue);
 				return;
 			case CDAPackage.CDA_TEMPLATE__TEMPLATE_VERSION:
-				setTemplateVersion((String) newValue);
+				setTemplateVersion((String)newValue);
+				return;
+			case CDAPackage.CDA_TEMPLATE__TEMPLATE_MULTIPLICITY:
+				setTemplateMultiplicity((String)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -209,7 +219,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -220,7 +229,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -238,6 +246,9 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 			case CDAPackage.CDA_TEMPLATE__TEMPLATE_VERSION:
 				setTemplateVersion(TEMPLATE_VERSION_EDEFAULT);
 				return;
+			case CDAPackage.CDA_TEMPLATE__TEMPLATE_MULTIPLICITY:
+				setTemplateMultiplicity(TEMPLATE_MULTIPLICITY_EDEFAULT);
+				return;
 		}
 		super.eUnset(featureID);
 	}
@@ -245,7 +256,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getAssigningAuthorityName() {
@@ -255,7 +265,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getTemplateId() {
@@ -265,7 +274,6 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public boolean isContextDependent() {
@@ -275,39 +283,30 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setAssigningAuthorityName(String newAssigningAuthorityName) {
 		String oldAssigningAuthorityName = assigningAuthorityName;
 		assigningAuthorityName = newAssigningAuthorityName;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CDA_TEMPLATE__ASSIGNING_AUTHORITY_NAME, oldAssigningAuthorityName,
-				assigningAuthorityName));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CDA_TEMPLATE__ASSIGNING_AUTHORITY_NAME, oldAssigningAuthorityName, assigningAuthorityName));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setContextDependent(boolean newContextDependent) {
 		boolean oldContextDependent = contextDependent;
 		contextDependent = newContextDependent;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CDA_TEMPLATE__CONTEXT_DEPENDENT, oldContextDependent,
-				contextDependent));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CDA_TEMPLATE__CONTEXT_DEPENDENT, oldContextDependent, contextDependent));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getTemplateVersion() {
@@ -317,44 +316,56 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setTemplateVersion(String newTemplateVersion) {
 		String oldTemplateVersion = templateVersion;
 		templateVersion = newTemplateVersion;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CDA_TEMPLATE__TEMPLATE_VERSION, oldTemplateVersion, templateVersion));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CDA_TEMPLATE__TEMPLATE_VERSION, oldTemplateVersion, templateVersion));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
+	 * @generated
+	 */
+	public String getTemplateMultiplicity() {
+		return templateMultiplicity;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setTemplateMultiplicity(String newTemplateMultiplicity) {
+		String oldTemplateMultiplicity = templateMultiplicity;
+		templateMultiplicity = newTemplateMultiplicity;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CDA_TEMPLATE__TEMPLATE_MULTIPLICITY, oldTemplateMultiplicity, templateMultiplicity));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @generated
 	 */
 	public void setTemplateId(String newTemplateId) {
 		String oldTemplateId = templateId;
 		templateId = newTemplateId;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CDA_TEMPLATE__TEMPLATE_ID, oldTemplateId, templateId));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CDA_TEMPLATE__TEMPLATE_ID, oldTemplateId, templateId));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (templateId: ");
@@ -365,6 +376,8 @@ public class CDATemplateImpl extends ClassValidationImpl implements CDATemplate 
 		result.append(contextDependent);
 		result.append(", templateVersion: ");
 		result.append(templateVersion);
+		result.append(", templateMultiplicity: ");
+		result.append(templateMultiplicity);
 		result.append(')');
 		return result.toString();
 	}

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ClassValidationImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ClassValidationImpl.java
@@ -26,10 +26,10 @@ import org.openhealthtools.mdht.uml.cda.core.profile.ClassValidation;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ClassValidationImpl#getBase_Class <em>Base Class</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ClassValidationImpl#getBase_Class <em>Base Class</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ClassValidationImpl extends ValidationImpl implements ClassValidation {
@@ -37,7 +37,6 @@ public class ClassValidationImpl extends ValidationImpl implements ClassValidati
 	 * The cached value of the '{@link #getBase_Class() <em>Base Class</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getBase_Class()
 	 * @generated
 	 * @ordered
@@ -47,7 +46,6 @@ public class ClassValidationImpl extends ValidationImpl implements ClassValidati
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected ClassValidationImpl() {
@@ -57,7 +55,6 @@ public class ClassValidationImpl extends ValidationImpl implements ClassValidati
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public org.eclipse.uml2.uml.Class basicGetBase_Class() {
@@ -67,16 +64,13 @@ public class ClassValidationImpl extends ValidationImpl implements ClassValidati
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
 			case CDAPackage.CLASS_VALIDATION__BASE_CLASS:
-				if (resolve) {
-					return getBase_Class();
-				}
+				if (resolve) return getBase_Class();
 				return basicGetBase_Class();
 		}
 		return super.eGet(featureID, resolve, coreType);
@@ -85,7 +79,6 @@ public class ClassValidationImpl extends ValidationImpl implements ClassValidati
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -100,14 +93,13 @@ public class ClassValidationImpl extends ValidationImpl implements ClassValidati
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.CLASS_VALIDATION__BASE_CLASS:
-				setBase_Class((org.eclipse.uml2.uml.Class) newValue);
+				setBase_Class((org.eclipse.uml2.uml.Class)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -116,7 +108,6 @@ public class ClassValidationImpl extends ValidationImpl implements ClassValidati
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -127,14 +118,13 @@ public class ClassValidationImpl extends ValidationImpl implements ClassValidati
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
 			case CDAPackage.CLASS_VALIDATION__BASE_CLASS:
-				setBase_Class((org.eclipse.uml2.uml.Class) null);
+				setBase_Class((org.eclipse.uml2.uml.Class)null);
 				return;
 		}
 		super.eUnset(featureID);
@@ -143,18 +133,15 @@ public class ClassValidationImpl extends ValidationImpl implements ClassValidati
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public org.eclipse.uml2.uml.Class getBase_Class() {
 		if (base_Class != null && base_Class.eIsProxy()) {
-			InternalEObject oldBase_Class = (InternalEObject) base_Class;
-			base_Class = (org.eclipse.uml2.uml.Class) eResolveProxy(oldBase_Class);
+			InternalEObject oldBase_Class = (InternalEObject)base_Class;
+			base_Class = (org.eclipse.uml2.uml.Class)eResolveProxy(oldBase_Class);
 			if (base_Class != oldBase_Class) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.CLASS_VALIDATION__BASE_CLASS, oldBase_Class, base_Class));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.CLASS_VALIDATION__BASE_CLASS, oldBase_Class, base_Class));
 			}
 		}
 		return base_Class;
@@ -163,16 +150,13 @@ public class ClassValidationImpl extends ValidationImpl implements ClassValidati
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setBase_Class(org.eclipse.uml2.uml.Class newBase_Class) {
 		org.eclipse.uml2.uml.Class oldBase_Class = base_Class;
 		base_Class = newBase_Class;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CLASS_VALIDATION__BASE_CLASS, oldBase_Class, base_Class));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CLASS_VALIDATION__BASE_CLASS, oldBase_Class, base_Class));
 	}
 
 } // ClassValidationImpl

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/CodeSystemConstraintImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/CodeSystemConstraintImpl.java
@@ -31,13 +31,13 @@ import org.openhealthtools.mdht.uml.cda.core.profile.Validation;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl#getMessage <em>Message</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl#getSeverity <em>Severity</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl#getRuleId <em>Rule Id</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl#isMandatory <em>Mandatory</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl#getMessage <em>Message</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl#getSeverity <em>Severity</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl#getRuleId <em>Rule Id</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodeSystemConstraintImpl#isMandatory <em>Mandatory</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class CodeSystemConstraintImpl extends
@@ -46,7 +46,6 @@ public class CodeSystemConstraintImpl extends
 	 * The default value of the '{@link #getMessage() <em>Message</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getMessage()
 	 * @generated
 	 * @ordered
@@ -57,7 +56,6 @@ public class CodeSystemConstraintImpl extends
 	 * The cached value of the '{@link #getMessage() <em>Message</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getMessage()
 	 * @generated
 	 * @ordered
@@ -68,7 +66,6 @@ public class CodeSystemConstraintImpl extends
 	 * The default value of the '{@link #getSeverity() <em>Severity</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getSeverity()
 	 * @generated
 	 * @ordered
@@ -79,7 +76,6 @@ public class CodeSystemConstraintImpl extends
 	 * The cached value of the '{@link #getSeverity() <em>Severity</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getSeverity()
 	 * @generated
 	 * @ordered
@@ -90,7 +86,6 @@ public class CodeSystemConstraintImpl extends
 	 * The cached value of the '{@link #getRuleId() <em>Rule Id</em>}' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getRuleId()
 	 * @generated
 	 * @ordered
@@ -101,7 +96,6 @@ public class CodeSystemConstraintImpl extends
 	 * The default value of the '{@link #isMandatory() <em>Mandatory</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isMandatory()
 	 * @generated
 	 * @ordered
@@ -112,7 +106,6 @@ public class CodeSystemConstraintImpl extends
 	 * The cached value of the '{@link #isMandatory() <em>Mandatory</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isMandatory()
 	 * @generated
 	 * @ordered
@@ -122,7 +115,6 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected CodeSystemConstraintImpl() {
@@ -132,23 +124,17 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public int eBaseStructuralFeatureID(int derivedFeatureID, Class<?> baseClass) {
 		if (baseClass == Validation.class) {
 			switch (derivedFeatureID) {
-				case CDAPackage.CODE_SYSTEM_CONSTRAINT__MESSAGE:
-					return CDAPackage.VALIDATION__MESSAGE;
-				case CDAPackage.CODE_SYSTEM_CONSTRAINT__SEVERITY:
-					return CDAPackage.VALIDATION__SEVERITY;
-				case CDAPackage.CODE_SYSTEM_CONSTRAINT__RULE_ID:
-					return CDAPackage.VALIDATION__RULE_ID;
-				case CDAPackage.CODE_SYSTEM_CONSTRAINT__MANDATORY:
-					return CDAPackage.VALIDATION__MANDATORY;
-				default:
-					return -1;
+				case CDAPackage.CODE_SYSTEM_CONSTRAINT__MESSAGE: return CDAPackage.VALIDATION__MESSAGE;
+				case CDAPackage.CODE_SYSTEM_CONSTRAINT__SEVERITY: return CDAPackage.VALIDATION__SEVERITY;
+				case CDAPackage.CODE_SYSTEM_CONSTRAINT__RULE_ID: return CDAPackage.VALIDATION__RULE_ID;
+				case CDAPackage.CODE_SYSTEM_CONSTRAINT__MANDATORY: return CDAPackage.VALIDATION__MANDATORY;
+				default: return -1;
 			}
 		}
 		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
@@ -157,23 +143,17 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public int eDerivedStructuralFeatureID(int baseFeatureID, Class<?> baseClass) {
 		if (baseClass == Validation.class) {
 			switch (baseFeatureID) {
-				case CDAPackage.VALIDATION__MESSAGE:
-					return CDAPackage.CODE_SYSTEM_CONSTRAINT__MESSAGE;
-				case CDAPackage.VALIDATION__SEVERITY:
-					return CDAPackage.CODE_SYSTEM_CONSTRAINT__SEVERITY;
-				case CDAPackage.VALIDATION__RULE_ID:
-					return CDAPackage.CODE_SYSTEM_CONSTRAINT__RULE_ID;
-				case CDAPackage.VALIDATION__MANDATORY:
-					return CDAPackage.CODE_SYSTEM_CONSTRAINT__MANDATORY;
-				default:
-					return -1;
+				case CDAPackage.VALIDATION__MESSAGE: return CDAPackage.CODE_SYSTEM_CONSTRAINT__MESSAGE;
+				case CDAPackage.VALIDATION__SEVERITY: return CDAPackage.CODE_SYSTEM_CONSTRAINT__SEVERITY;
+				case CDAPackage.VALIDATION__RULE_ID: return CDAPackage.CODE_SYSTEM_CONSTRAINT__RULE_ID;
+				case CDAPackage.VALIDATION__MANDATORY: return CDAPackage.CODE_SYSTEM_CONSTRAINT__MANDATORY;
+				default: return -1;
 			}
 		}
 		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
@@ -182,7 +162,6 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -203,16 +182,13 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
 			case CDAPackage.CODE_SYSTEM_CONSTRAINT__MESSAGE:
-				return MESSAGE_EDEFAULT == null
-						? message != null
-						: !MESSAGE_EDEFAULT.equals(message);
+				return MESSAGE_EDEFAULT == null ? message != null : !MESSAGE_EDEFAULT.equals(message);
 			case CDAPackage.CODE_SYSTEM_CONSTRAINT__SEVERITY:
 				return severity != SEVERITY_EDEFAULT;
 			case CDAPackage.CODE_SYSTEM_CONSTRAINT__RULE_ID:
@@ -226,7 +202,6 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -234,17 +209,17 @@ public class CodeSystemConstraintImpl extends
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.CODE_SYSTEM_CONSTRAINT__MESSAGE:
-				setMessage((String) newValue);
+				setMessage((String)newValue);
 				return;
 			case CDAPackage.CODE_SYSTEM_CONSTRAINT__SEVERITY:
-				setSeverity((SeverityKind) newValue);
+				setSeverity((SeverityKind)newValue);
 				return;
 			case CDAPackage.CODE_SYSTEM_CONSTRAINT__RULE_ID:
 				getRuleId().clear();
-				getRuleId().addAll((Collection<? extends String>) newValue);
+				getRuleId().addAll((Collection<? extends String>)newValue);
 				return;
 			case CDAPackage.CODE_SYSTEM_CONSTRAINT__MANDATORY:
-				setMandatory((Boolean) newValue);
+				setMandatory((Boolean)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -253,7 +228,6 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -264,7 +238,6 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -289,7 +262,6 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getMessage() {
@@ -299,7 +271,6 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EList<String> getRuleId() {
@@ -312,7 +283,6 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public SeverityKind getSeverity() {
@@ -322,7 +292,6 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public boolean isMandatory() {
@@ -332,61 +301,47 @@ public class CodeSystemConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setMandatory(boolean newMandatory) {
 		boolean oldMandatory = mandatory;
 		mandatory = newMandatory;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CODE_SYSTEM_CONSTRAINT__MANDATORY, oldMandatory, mandatory));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CODE_SYSTEM_CONSTRAINT__MANDATORY, oldMandatory, mandatory));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setMessage(String newMessage) {
 		String oldMessage = message;
 		message = newMessage;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CODE_SYSTEM_CONSTRAINT__MESSAGE, oldMessage, message));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CODE_SYSTEM_CONSTRAINT__MESSAGE, oldMessage, message));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setSeverity(SeverityKind newSeverity) {
 		SeverityKind oldSeverity = severity;
-		severity = newSeverity == null
-				? SEVERITY_EDEFAULT
-				: newSeverity;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CODE_SYSTEM_CONSTRAINT__SEVERITY, oldSeverity, severity));
-		}
+		severity = newSeverity == null ? SEVERITY_EDEFAULT : newSeverity;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CODE_SYSTEM_CONSTRAINT__SEVERITY, oldSeverity, severity));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (message: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/CodegenSupportImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/CodegenSupportImpl.java
@@ -28,15 +28,15 @@ import org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl#getBasePackage <em>Base Package</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl#getNsPrefix <em>Ns Prefix</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl#getNsURI <em>Ns URI</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl#getPackageName <em>Package Name</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl#getPrefix <em>Prefix</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl#getBase_Namespace <em>Base Namespace</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl#getBasePackage <em>Base Package</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl#getNsPrefix <em>Ns Prefix</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl#getNsURI <em>Ns URI</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl#getPackageName <em>Package Name</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl#getPrefix <em>Prefix</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.CodegenSupportImpl#getBase_Namespace <em>Base Namespace</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
@@ -44,7 +44,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	 * The default value of the '{@link #getBasePackage() <em>Base Package</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getBasePackage()
 	 * @generated
 	 * @ordered
@@ -55,7 +54,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	 * The cached value of the '{@link #getBasePackage() <em>Base Package</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getBasePackage()
 	 * @generated
 	 * @ordered
@@ -66,7 +64,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	 * The default value of the '{@link #getNsPrefix() <em>Ns Prefix</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getNsPrefix()
 	 * @generated
 	 * @ordered
@@ -77,7 +74,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	 * The cached value of the '{@link #getNsPrefix() <em>Ns Prefix</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getNsPrefix()
 	 * @generated
 	 * @ordered
@@ -88,7 +84,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	 * The default value of the '{@link #getNsURI() <em>Ns URI</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getNsURI()
 	 * @generated
 	 * @ordered
@@ -99,7 +94,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	 * The cached value of the '{@link #getNsURI() <em>Ns URI</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getNsURI()
 	 * @generated
 	 * @ordered
@@ -110,7 +104,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	 * The default value of the '{@link #getPackageName() <em>Package Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getPackageName()
 	 * @generated
 	 * @ordered
@@ -121,7 +114,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	 * The cached value of the '{@link #getPackageName() <em>Package Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getPackageName()
 	 * @generated
 	 * @ordered
@@ -132,7 +124,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	 * The default value of the '{@link #getPrefix() <em>Prefix</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getPrefix()
 	 * @generated
 	 * @ordered
@@ -143,7 +134,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	 * The cached value of the '{@link #getPrefix() <em>Prefix</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getPrefix()
 	 * @generated
 	 * @ordered
@@ -154,7 +144,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	 * The cached value of the '{@link #getBase_Namespace() <em>Base Namespace</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getBase_Namespace()
 	 * @generated
 	 * @ordered
@@ -164,7 +153,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected CodegenSupportImpl() {
@@ -174,7 +162,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Namespace basicGetBase_Namespace() {
@@ -184,7 +171,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -201,9 +187,7 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 			case CDAPackage.CODEGEN_SUPPORT__PREFIX:
 				return getPrefix();
 			case CDAPackage.CODEGEN_SUPPORT__BASE_NAMESPACE:
-				if (resolve) {
-					return getBase_Namespace();
-				}
+				if (resolve) return getBase_Namespace();
 				return basicGetBase_Namespace();
 		}
 		return super.eGet(featureID, resolve, coreType);
@@ -212,32 +196,21 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
 			case CDAPackage.CODEGEN_SUPPORT__BASE_PACKAGE:
-				return BASE_PACKAGE_EDEFAULT == null
-						? basePackage != null
-						: !BASE_PACKAGE_EDEFAULT.equals(basePackage);
+				return BASE_PACKAGE_EDEFAULT == null ? basePackage != null : !BASE_PACKAGE_EDEFAULT.equals(basePackage);
 			case CDAPackage.CODEGEN_SUPPORT__NS_PREFIX:
-				return NS_PREFIX_EDEFAULT == null
-						? nsPrefix != null
-						: !NS_PREFIX_EDEFAULT.equals(nsPrefix);
+				return NS_PREFIX_EDEFAULT == null ? nsPrefix != null : !NS_PREFIX_EDEFAULT.equals(nsPrefix);
 			case CDAPackage.CODEGEN_SUPPORT__NS_URI:
-				return NS_URI_EDEFAULT == null
-						? nsURI != null
-						: !NS_URI_EDEFAULT.equals(nsURI);
+				return NS_URI_EDEFAULT == null ? nsURI != null : !NS_URI_EDEFAULT.equals(nsURI);
 			case CDAPackage.CODEGEN_SUPPORT__PACKAGE_NAME:
-				return PACKAGE_NAME_EDEFAULT == null
-						? packageName != null
-						: !PACKAGE_NAME_EDEFAULT.equals(packageName);
+				return PACKAGE_NAME_EDEFAULT == null ? packageName != null : !PACKAGE_NAME_EDEFAULT.equals(packageName);
 			case CDAPackage.CODEGEN_SUPPORT__PREFIX:
-				return PREFIX_EDEFAULT == null
-						? prefix != null
-						: !PREFIX_EDEFAULT.equals(prefix);
+				return PREFIX_EDEFAULT == null ? prefix != null : !PREFIX_EDEFAULT.equals(prefix);
 			case CDAPackage.CODEGEN_SUPPORT__BASE_NAMESPACE:
 				return base_Namespace != null;
 		}
@@ -247,29 +220,28 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.CODEGEN_SUPPORT__BASE_PACKAGE:
-				setBasePackage((String) newValue);
+				setBasePackage((String)newValue);
 				return;
 			case CDAPackage.CODEGEN_SUPPORT__NS_PREFIX:
-				setNsPrefix((String) newValue);
+				setNsPrefix((String)newValue);
 				return;
 			case CDAPackage.CODEGEN_SUPPORT__NS_URI:
-				setNsURI((String) newValue);
+				setNsURI((String)newValue);
 				return;
 			case CDAPackage.CODEGEN_SUPPORT__PACKAGE_NAME:
-				setPackageName((String) newValue);
+				setPackageName((String)newValue);
 				return;
 			case CDAPackage.CODEGEN_SUPPORT__PREFIX:
-				setPrefix((String) newValue);
+				setPrefix((String)newValue);
 				return;
 			case CDAPackage.CODEGEN_SUPPORT__BASE_NAMESPACE:
-				setBase_Namespace((Namespace) newValue);
+				setBase_Namespace((Namespace)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -278,7 +250,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -289,7 +260,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -311,7 +281,7 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 				setPrefix(PREFIX_EDEFAULT);
 				return;
 			case CDAPackage.CODEGEN_SUPPORT__BASE_NAMESPACE:
-				setBase_Namespace((Namespace) null);
+				setBase_Namespace((Namespace)null);
 				return;
 		}
 		super.eUnset(featureID);
@@ -320,19 +290,15 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Namespace getBase_Namespace() {
 		if (base_Namespace != null && base_Namespace.eIsProxy()) {
-			InternalEObject oldBase_Namespace = (InternalEObject) base_Namespace;
-			base_Namespace = (Namespace) eResolveProxy(oldBase_Namespace);
+			InternalEObject oldBase_Namespace = (InternalEObject)base_Namespace;
+			base_Namespace = (Namespace)eResolveProxy(oldBase_Namespace);
 			if (base_Namespace != oldBase_Namespace) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.CODEGEN_SUPPORT__BASE_NAMESPACE, oldBase_Namespace,
-						base_Namespace));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.CODEGEN_SUPPORT__BASE_NAMESPACE, oldBase_Namespace, base_Namespace));
 			}
 		}
 		return base_Namespace;
@@ -341,7 +307,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getBasePackage() {
@@ -351,7 +316,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getNsPrefix() {
@@ -361,7 +325,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getNsURI() {
@@ -371,7 +334,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getPackageName() {
@@ -381,7 +343,6 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getPrefix() {
@@ -391,102 +352,83 @@ public class CodegenSupportImpl extends EObjectImpl implements CodegenSupport {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setBase_Namespace(Namespace newBase_Namespace) {
 		Namespace oldBase_Namespace = base_Namespace;
 		base_Namespace = newBase_Namespace;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CODEGEN_SUPPORT__BASE_NAMESPACE, oldBase_Namespace, base_Namespace));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CODEGEN_SUPPORT__BASE_NAMESPACE, oldBase_Namespace, base_Namespace));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setBasePackage(String newBasePackage) {
 		String oldBasePackage = basePackage;
 		basePackage = newBasePackage;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CODEGEN_SUPPORT__BASE_PACKAGE, oldBasePackage, basePackage));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CODEGEN_SUPPORT__BASE_PACKAGE, oldBasePackage, basePackage));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setNsPrefix(String newNsPrefix) {
 		String oldNsPrefix = nsPrefix;
 		nsPrefix = newNsPrefix;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CODEGEN_SUPPORT__NS_PREFIX, oldNsPrefix, nsPrefix));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CODEGEN_SUPPORT__NS_PREFIX, oldNsPrefix, nsPrefix));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setNsURI(String newNsURI) {
 		String oldNsURI = nsURI;
 		nsURI = newNsURI;
-		if (eNotificationRequired()) {
+		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CODEGEN_SUPPORT__NS_URI, oldNsURI, nsURI));
-		}
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setPackageName(String newPackageName) {
 		String oldPackageName = packageName;
 		packageName = newPackageName;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CODEGEN_SUPPORT__PACKAGE_NAME, oldPackageName, packageName));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CODEGEN_SUPPORT__PACKAGE_NAME, oldPackageName, packageName));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setPrefix(String newPrefix) {
 		String oldPrefix = prefix;
 		prefix = newPrefix;
-		if (eNotificationRequired()) {
+		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CODEGEN_SUPPORT__PREFIX, oldPrefix, prefix));
-		}
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (basePackage: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ConceptDomainConstraintImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ConceptDomainConstraintImpl.java
@@ -31,13 +31,13 @@ import org.openhealthtools.mdht.uml.cda.core.profile.Validation;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl#getMessage <em>Message</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl#getSeverity <em>Severity</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl#getRuleId <em>Rule Id</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl#isMandatory <em>Mandatory</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl#getMessage <em>Message</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl#getSeverity <em>Severity</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl#getRuleId <em>Rule Id</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConceptDomainConstraintImpl#isMandatory <em>Mandatory</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ConceptDomainConstraintImpl extends
@@ -47,7 +47,6 @@ public class ConceptDomainConstraintImpl extends
 	 * The default value of the '{@link #getMessage() <em>Message</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getMessage()
 	 * @generated
 	 * @ordered
@@ -58,7 +57,6 @@ public class ConceptDomainConstraintImpl extends
 	 * The cached value of the '{@link #getMessage() <em>Message</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getMessage()
 	 * @generated
 	 * @ordered
@@ -69,7 +67,6 @@ public class ConceptDomainConstraintImpl extends
 	 * The default value of the '{@link #getSeverity() <em>Severity</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getSeverity()
 	 * @generated
 	 * @ordered
@@ -80,7 +77,6 @@ public class ConceptDomainConstraintImpl extends
 	 * The cached value of the '{@link #getSeverity() <em>Severity</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getSeverity()
 	 * @generated
 	 * @ordered
@@ -91,7 +87,6 @@ public class ConceptDomainConstraintImpl extends
 	 * The cached value of the '{@link #getRuleId() <em>Rule Id</em>}' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getRuleId()
 	 * @generated
 	 * @ordered
@@ -102,7 +97,6 @@ public class ConceptDomainConstraintImpl extends
 	 * The default value of the '{@link #isMandatory() <em>Mandatory</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isMandatory()
 	 * @generated
 	 * @ordered
@@ -113,7 +107,6 @@ public class ConceptDomainConstraintImpl extends
 	 * The cached value of the '{@link #isMandatory() <em>Mandatory</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isMandatory()
 	 * @generated
 	 * @ordered
@@ -123,7 +116,6 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected ConceptDomainConstraintImpl() {
@@ -133,23 +125,17 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public int eBaseStructuralFeatureID(int derivedFeatureID, Class<?> baseClass) {
 		if (baseClass == Validation.class) {
 			switch (derivedFeatureID) {
-				case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MESSAGE:
-					return CDAPackage.VALIDATION__MESSAGE;
-				case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__SEVERITY:
-					return CDAPackage.VALIDATION__SEVERITY;
-				case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__RULE_ID:
-					return CDAPackage.VALIDATION__RULE_ID;
-				case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MANDATORY:
-					return CDAPackage.VALIDATION__MANDATORY;
-				default:
-					return -1;
+				case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MESSAGE: return CDAPackage.VALIDATION__MESSAGE;
+				case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__SEVERITY: return CDAPackage.VALIDATION__SEVERITY;
+				case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__RULE_ID: return CDAPackage.VALIDATION__RULE_ID;
+				case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MANDATORY: return CDAPackage.VALIDATION__MANDATORY;
+				default: return -1;
 			}
 		}
 		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
@@ -158,23 +144,17 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public int eDerivedStructuralFeatureID(int baseFeatureID, Class<?> baseClass) {
 		if (baseClass == Validation.class) {
 			switch (baseFeatureID) {
-				case CDAPackage.VALIDATION__MESSAGE:
-					return CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MESSAGE;
-				case CDAPackage.VALIDATION__SEVERITY:
-					return CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__SEVERITY;
-				case CDAPackage.VALIDATION__RULE_ID:
-					return CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__RULE_ID;
-				case CDAPackage.VALIDATION__MANDATORY:
-					return CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MANDATORY;
-				default:
-					return -1;
+				case CDAPackage.VALIDATION__MESSAGE: return CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MESSAGE;
+				case CDAPackage.VALIDATION__SEVERITY: return CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__SEVERITY;
+				case CDAPackage.VALIDATION__RULE_ID: return CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__RULE_ID;
+				case CDAPackage.VALIDATION__MANDATORY: return CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MANDATORY;
+				default: return -1;
 			}
 		}
 		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
@@ -183,7 +163,6 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -204,16 +183,13 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
 			case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MESSAGE:
-				return MESSAGE_EDEFAULT == null
-						? message != null
-						: !MESSAGE_EDEFAULT.equals(message);
+				return MESSAGE_EDEFAULT == null ? message != null : !MESSAGE_EDEFAULT.equals(message);
 			case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__SEVERITY:
 				return severity != SEVERITY_EDEFAULT;
 			case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__RULE_ID:
@@ -227,7 +203,6 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -235,17 +210,17 @@ public class ConceptDomainConstraintImpl extends
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MESSAGE:
-				setMessage((String) newValue);
+				setMessage((String)newValue);
 				return;
 			case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__SEVERITY:
-				setSeverity((SeverityKind) newValue);
+				setSeverity((SeverityKind)newValue);
 				return;
 			case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__RULE_ID:
 				getRuleId().clear();
-				getRuleId().addAll((Collection<? extends String>) newValue);
+				getRuleId().addAll((Collection<? extends String>)newValue);
 				return;
 			case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MANDATORY:
-				setMandatory((Boolean) newValue);
+				setMandatory((Boolean)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -254,7 +229,6 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -265,7 +239,6 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -290,7 +263,6 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getMessage() {
@@ -300,7 +272,6 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EList<String> getRuleId() {
@@ -313,7 +284,6 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public SeverityKind getSeverity() {
@@ -323,7 +293,6 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public boolean isMandatory() {
@@ -333,61 +302,47 @@ public class ConceptDomainConstraintImpl extends
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setMandatory(boolean newMandatory) {
 		boolean oldMandatory = mandatory;
 		mandatory = newMandatory;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MANDATORY, oldMandatory, mandatory));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MANDATORY, oldMandatory, mandatory));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setMessage(String newMessage) {
 		String oldMessage = message;
 		message = newMessage;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MESSAGE, oldMessage, message));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__MESSAGE, oldMessage, message));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setSeverity(SeverityKind newSeverity) {
 		SeverityKind oldSeverity = severity;
-		severity = newSeverity == null
-				? SEVERITY_EDEFAULT
-				: newSeverity;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__SEVERITY, oldSeverity, severity));
-		}
+		severity = newSeverity == null ? SEVERITY_EDEFAULT : newSeverity;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CONCEPT_DOMAIN_CONSTRAINT__SEVERITY, oldSeverity, severity));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (message: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ConformsToImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ConformsToImpl.java
@@ -27,11 +27,11 @@ import org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConformsToImpl#getBase_Generalization <em>Base Generalization</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConformsToImpl#isRequiresParentId <em>Requires Parent Id</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConformsToImpl#getBase_Generalization <em>Base Generalization</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConformsToImpl#isRequiresParentId <em>Requires Parent Id</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ConformsToImpl extends ValidationImpl implements ConformsTo {
@@ -39,7 +39,6 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	 * The cached value of the '{@link #getBase_Generalization() <em>Base Generalization</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getBase_Generalization()
 	 * @generated
 	 * @ordered
@@ -50,7 +49,6 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	 * The default value of the '{@link #isRequiresParentId() <em>Requires Parent Id</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isRequiresParentId()
 	 * @generated
 	 * @ordered
@@ -61,7 +59,6 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	 * The cached value of the '{@link #isRequiresParentId() <em>Requires Parent Id</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isRequiresParentId()
 	 * @generated
 	 * @ordered
@@ -71,7 +68,6 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected ConformsToImpl() {
@@ -81,7 +77,6 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Generalization basicGetBase_Generalization() {
@@ -91,16 +86,13 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
 			case CDAPackage.CONFORMS_TO__BASE_GENERALIZATION:
-				if (resolve) {
-					return getBase_Generalization();
-				}
+				if (resolve) return getBase_Generalization();
 				return basicGetBase_Generalization();
 			case CDAPackage.CONFORMS_TO__REQUIRES_PARENT_ID:
 				return isRequiresParentId();
@@ -111,7 +103,6 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -128,17 +119,16 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.CONFORMS_TO__BASE_GENERALIZATION:
-				setBase_Generalization((Generalization) newValue);
+				setBase_Generalization((Generalization)newValue);
 				return;
 			case CDAPackage.CONFORMS_TO__REQUIRES_PARENT_ID:
-				setRequiresParentId((Boolean) newValue);
+				setRequiresParentId((Boolean)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -147,7 +137,6 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -158,14 +147,13 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
 			case CDAPackage.CONFORMS_TO__BASE_GENERALIZATION:
-				setBase_Generalization((Generalization) null);
+				setBase_Generalization((Generalization)null);
 				return;
 			case CDAPackage.CONFORMS_TO__REQUIRES_PARENT_ID:
 				setRequiresParentId(REQUIRES_PARENT_ID_EDEFAULT);
@@ -177,19 +165,15 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Generalization getBase_Generalization() {
 		if (base_Generalization != null && base_Generalization.eIsProxy()) {
-			InternalEObject oldBase_Generalization = (InternalEObject) base_Generalization;
-			base_Generalization = (Generalization) eResolveProxy(oldBase_Generalization);
+			InternalEObject oldBase_Generalization = (InternalEObject)base_Generalization;
+			base_Generalization = (Generalization)eResolveProxy(oldBase_Generalization);
 			if (base_Generalization != oldBase_Generalization) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.CONFORMS_TO__BASE_GENERALIZATION,
-						oldBase_Generalization, base_Generalization));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.CONFORMS_TO__BASE_GENERALIZATION, oldBase_Generalization, base_Generalization));
 			}
 		}
 		return base_Generalization;
@@ -198,7 +182,6 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public boolean isRequiresParentId() {
@@ -208,46 +191,35 @@ public class ConformsToImpl extends ValidationImpl implements ConformsTo {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setBase_Generalization(Generalization newBase_Generalization) {
 		Generalization oldBase_Generalization = base_Generalization;
 		base_Generalization = newBase_Generalization;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CONFORMS_TO__BASE_GENERALIZATION, oldBase_Generalization,
-				base_Generalization));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CONFORMS_TO__BASE_GENERALIZATION, oldBase_Generalization, base_Generalization));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setRequiresParentId(boolean newRequiresParentId) {
 		boolean oldRequiresParentId = requiresParentId;
 		requiresParentId = newRequiresParentId;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CONFORMS_TO__REQUIRES_PARENT_ID, oldRequiresParentId,
-				requiresParentId));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CONFORMS_TO__REQUIRES_PARENT_ID, oldRequiresParentId, requiresParentId));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (requiresParentId: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ConstraintValidationImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ConstraintValidationImpl.java
@@ -27,10 +27,10 @@ import org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConstraintValidationImpl#getBase_Constraint <em>Base Constraint</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ConstraintValidationImpl#getBase_Constraint <em>Base Constraint</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ConstraintValidationImpl extends ValidationImpl implements ConstraintValidation {
@@ -38,7 +38,6 @@ public class ConstraintValidationImpl extends ValidationImpl implements Constrai
 	 * The cached value of the '{@link #getBase_Constraint() <em>Base Constraint</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getBase_Constraint()
 	 * @generated
 	 * @ordered
@@ -48,7 +47,6 @@ public class ConstraintValidationImpl extends ValidationImpl implements Constrai
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected ConstraintValidationImpl() {
@@ -58,7 +56,6 @@ public class ConstraintValidationImpl extends ValidationImpl implements Constrai
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Constraint basicGetBase_Constraint() {
@@ -68,16 +65,13 @@ public class ConstraintValidationImpl extends ValidationImpl implements Constrai
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
 			case CDAPackage.CONSTRAINT_VALIDATION__BASE_CONSTRAINT:
-				if (resolve) {
-					return getBase_Constraint();
-				}
+				if (resolve) return getBase_Constraint();
 				return basicGetBase_Constraint();
 		}
 		return super.eGet(featureID, resolve, coreType);
@@ -86,7 +80,6 @@ public class ConstraintValidationImpl extends ValidationImpl implements Constrai
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -101,14 +94,13 @@ public class ConstraintValidationImpl extends ValidationImpl implements Constrai
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.CONSTRAINT_VALIDATION__BASE_CONSTRAINT:
-				setBase_Constraint((Constraint) newValue);
+				setBase_Constraint((Constraint)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -117,7 +109,6 @@ public class ConstraintValidationImpl extends ValidationImpl implements Constrai
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -128,14 +119,13 @@ public class ConstraintValidationImpl extends ValidationImpl implements Constrai
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
 			case CDAPackage.CONSTRAINT_VALIDATION__BASE_CONSTRAINT:
-				setBase_Constraint((Constraint) null);
+				setBase_Constraint((Constraint)null);
 				return;
 		}
 		super.eUnset(featureID);
@@ -144,19 +134,15 @@ public class ConstraintValidationImpl extends ValidationImpl implements Constrai
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Constraint getBase_Constraint() {
 		if (base_Constraint != null && base_Constraint.eIsProxy()) {
-			InternalEObject oldBase_Constraint = (InternalEObject) base_Constraint;
-			base_Constraint = (Constraint) eResolveProxy(oldBase_Constraint);
+			InternalEObject oldBase_Constraint = (InternalEObject)base_Constraint;
+			base_Constraint = (Constraint)eResolveProxy(oldBase_Constraint);
 			if (base_Constraint != oldBase_Constraint) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.CONSTRAINT_VALIDATION__BASE_CONSTRAINT,
-						oldBase_Constraint, base_Constraint));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.CONSTRAINT_VALIDATION__BASE_CONSTRAINT, oldBase_Constraint, base_Constraint));
 			}
 		}
 		return base_Constraint;
@@ -165,17 +151,13 @@ public class ConstraintValidationImpl extends ValidationImpl implements Constrai
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setBase_Constraint(Constraint newBase_Constraint) {
 		Constraint oldBase_Constraint = base_Constraint;
 		base_Constraint = newBase_Constraint;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.CONSTRAINT_VALIDATION__BASE_CONSTRAINT, oldBase_Constraint,
-				base_Constraint));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.CONSTRAINT_VALIDATION__BASE_CONSTRAINT, oldBase_Constraint, base_Constraint));
 	}
 
 } // ConstraintValidationImpl

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/EntryImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/EntryImpl.java
@@ -27,10 +27,10 @@ import org.openhealthtools.mdht.uml.cda.core.profile.EntryKind;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryImpl#getTypeCode <em>Type Code</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryImpl#getTypeCode <em>Type Code</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class EntryImpl extends AssociationValidationImpl implements Entry {
@@ -38,7 +38,6 @@ public class EntryImpl extends AssociationValidationImpl implements Entry {
 	 * The default value of the '{@link #getTypeCode() <em>Type Code</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getTypeCode()
 	 * @generated
 	 * @ordered
@@ -49,7 +48,6 @@ public class EntryImpl extends AssociationValidationImpl implements Entry {
 	 * The cached value of the '{@link #getTypeCode() <em>Type Code</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getTypeCode()
 	 * @generated
 	 * @ordered
@@ -59,7 +57,6 @@ public class EntryImpl extends AssociationValidationImpl implements Entry {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected EntryImpl() {
@@ -69,7 +66,6 @@ public class EntryImpl extends AssociationValidationImpl implements Entry {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -84,7 +80,6 @@ public class EntryImpl extends AssociationValidationImpl implements Entry {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -119,7 +114,6 @@ public class EntryImpl extends AssociationValidationImpl implements Entry {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -130,7 +124,6 @@ public class EntryImpl extends AssociationValidationImpl implements Entry {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -146,7 +139,6 @@ public class EntryImpl extends AssociationValidationImpl implements Entry {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EntryKind getTypeCode() {
@@ -156,30 +148,23 @@ public class EntryImpl extends AssociationValidationImpl implements Entry {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setTypeCode(EntryKind newTypeCode) {
 		EntryKind oldTypeCode = typeCode;
-		typeCode = newTypeCode == null
-				? TYPE_CODE_EDEFAULT
-				: newTypeCode;
-		if (eNotificationRequired()) {
+		typeCode = newTypeCode == null ? TYPE_CODE_EDEFAULT : newTypeCode;
+		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.ENTRY__TYPE_CODE, oldTypeCode, typeCode));
-		}
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (typeCode: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/EntryRelationshipImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/EntryRelationshipImpl.java
@@ -27,10 +27,10 @@ import org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryRelationshipImpl#getTypeCode <em>Type Code</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.EntryRelationshipImpl#getTypeCode <em>Type Code</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class EntryRelationshipImpl extends AssociationValidationImpl implements EntryRelationship {
@@ -38,7 +38,6 @@ public class EntryRelationshipImpl extends AssociationValidationImpl implements 
 	 * The default value of the '{@link #getTypeCode() <em>Type Code</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getTypeCode()
 	 * @generated
 	 * @ordered
@@ -49,7 +48,6 @@ public class EntryRelationshipImpl extends AssociationValidationImpl implements 
 	 * The cached value of the '{@link #getTypeCode() <em>Type Code</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getTypeCode()
 	 * @generated
 	 * @ordered
@@ -59,7 +57,6 @@ public class EntryRelationshipImpl extends AssociationValidationImpl implements 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected EntryRelationshipImpl() {
@@ -69,7 +66,6 @@ public class EntryRelationshipImpl extends AssociationValidationImpl implements 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -84,7 +80,6 @@ public class EntryRelationshipImpl extends AssociationValidationImpl implements 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -119,7 +114,6 @@ public class EntryRelationshipImpl extends AssociationValidationImpl implements 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -130,7 +124,6 @@ public class EntryRelationshipImpl extends AssociationValidationImpl implements 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -146,7 +139,6 @@ public class EntryRelationshipImpl extends AssociationValidationImpl implements 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EntryRelationshipKind getTypeCode() {
@@ -156,31 +148,23 @@ public class EntryRelationshipImpl extends AssociationValidationImpl implements 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setTypeCode(EntryRelationshipKind newTypeCode) {
 		EntryRelationshipKind oldTypeCode = typeCode;
-		typeCode = newTypeCode == null
-				? TYPE_CODE_EDEFAULT
-				: newTypeCode;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.ENTRY_RELATIONSHIP__TYPE_CODE, oldTypeCode, typeCode));
-		}
+		typeCode = newTypeCode == null ? TYPE_CODE_EDEFAULT : newTypeCode;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.ENTRY_RELATIONSHIP__TYPE_CODE, oldTypeCode, typeCode));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (typeCode: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/InlineImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/InlineImpl.java
@@ -20,12 +20,12 @@ import org.openhealthtools.mdht.uml.cda.core.profile.Inline;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.InlineImpl#getBase_Class <em>Base Class</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.InlineImpl#getFilter <em>Filter</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.InlineImpl#isPublishSeperately <em>Publish Seperately</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.InlineImpl#getBase_Class <em>Base Class</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.InlineImpl#getFilter <em>Filter</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.InlineImpl#isPublishSeperately <em>Publish Seperately</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class InlineImpl extends EObjectImpl implements Inline {
@@ -33,7 +33,6 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	 * The cached value of the '{@link #getBase_Class() <em>Base Class</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getBase_Class()
 	 * @generated
 	 * @ordered
@@ -44,7 +43,6 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	 * The default value of the '{@link #getFilter() <em>Filter</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getFilter()
 	 * @generated
 	 * @ordered
@@ -55,7 +53,6 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	 * The cached value of the '{@link #getFilter() <em>Filter</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getFilter()
 	 * @generated
 	 * @ordered
@@ -66,7 +63,6 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	 * The default value of the '{@link #isPublishSeperately() <em>Publish Seperately</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isPublishSeperately()
 	 * @generated
 	 * @ordered
@@ -77,7 +73,6 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	 * The cached value of the '{@link #isPublishSeperately() <em>Publish Seperately</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isPublishSeperately()
 	 * @generated
 	 * @ordered
@@ -87,7 +82,6 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected InlineImpl() {
@@ -97,7 +91,6 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -108,18 +101,15 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public org.eclipse.uml2.uml.Class getBase_Class() {
 		if (base_Class != null && base_Class.eIsProxy()) {
-			InternalEObject oldBase_Class = (InternalEObject) base_Class;
-			base_Class = (org.eclipse.uml2.uml.Class) eResolveProxy(oldBase_Class);
+			InternalEObject oldBase_Class = (InternalEObject)base_Class;
+			base_Class = (org.eclipse.uml2.uml.Class)eResolveProxy(oldBase_Class);
 			if (base_Class != oldBase_Class) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.INLINE__BASE_CLASS, oldBase_Class, base_Class));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.INLINE__BASE_CLASS, oldBase_Class, base_Class));
 			}
 		}
 		return base_Class;
@@ -128,7 +118,6 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public org.eclipse.uml2.uml.Class basicGetBase_Class() {
@@ -138,22 +127,18 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setBase_Class(org.eclipse.uml2.uml.Class newBase_Class) {
 		org.eclipse.uml2.uml.Class oldBase_Class = base_Class;
 		base_Class = newBase_Class;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.INLINE__BASE_CLASS, oldBase_Class, base_Class));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.INLINE__BASE_CLASS, oldBase_Class, base_Class));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getFilter() {
@@ -163,21 +148,18 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setFilter(String newFilter) {
 		String oldFilter = filter;
 		filter = newFilter;
-		if (eNotificationRequired()) {
+		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.INLINE__FILTER, oldFilter, filter));
-		}
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public boolean isPublishSeperately() {
@@ -187,31 +169,25 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setPublishSeperately(boolean newPublishSeperately) {
 		boolean oldPublishSeperately = publishSeperately;
 		publishSeperately = newPublishSeperately;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.INLINE__PUBLISH_SEPERATELY, oldPublishSeperately, publishSeperately));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.INLINE__PUBLISH_SEPERATELY, oldPublishSeperately, publishSeperately));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
 			case CDAPackage.INLINE__BASE_CLASS:
-				if (resolve) {
-					return getBase_Class();
-				}
+				if (resolve) return getBase_Class();
 				return basicGetBase_Class();
 			case CDAPackage.INLINE__FILTER:
 				return getFilter();
@@ -224,20 +200,19 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.INLINE__BASE_CLASS:
-				setBase_Class((org.eclipse.uml2.uml.Class) newValue);
+				setBase_Class((org.eclipse.uml2.uml.Class)newValue);
 				return;
 			case CDAPackage.INLINE__FILTER:
-				setFilter((String) newValue);
+				setFilter((String)newValue);
 				return;
 			case CDAPackage.INLINE__PUBLISH_SEPERATELY:
-				setPublishSeperately((Boolean) newValue);
+				setPublishSeperately((Boolean)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -246,14 +221,13 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
 			case CDAPackage.INLINE__BASE_CLASS:
-				setBase_Class((org.eclipse.uml2.uml.Class) null);
+				setBase_Class((org.eclipse.uml2.uml.Class)null);
 				return;
 			case CDAPackage.INLINE__FILTER:
 				setFilter(FILTER_EDEFAULT);
@@ -268,7 +242,6 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -277,9 +250,7 @@ public class InlineImpl extends EObjectImpl implements Inline {
 			case CDAPackage.INLINE__BASE_CLASS:
 				return base_Class != null;
 			case CDAPackage.INLINE__FILTER:
-				return FILTER_EDEFAULT == null
-						? filter != null
-						: !FILTER_EDEFAULT.equals(filter);
+				return FILTER_EDEFAULT == null ? filter != null : !FILTER_EDEFAULT.equals(filter);
 			case CDAPackage.INLINE__PUBLISH_SEPERATELY:
 				return publishSeperately != PUBLISH_SEPERATELY_EDEFAULT;
 		}
@@ -289,14 +260,11 @@ public class InlineImpl extends EObjectImpl implements Inline {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (filter: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/LogicalConstraintImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/LogicalConstraintImpl.java
@@ -19,10 +19,10 @@ import org.openhealthtools.mdht.uml.cda.core.profile.LogicalOperator;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.LogicalConstraintImpl#getOperation <em>Operation</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.LogicalConstraintImpl#getOperation <em>Operation</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class LogicalConstraintImpl extends ConstraintValidationImpl implements LogicalConstraint {
@@ -30,7 +30,6 @@ public class LogicalConstraintImpl extends ConstraintValidationImpl implements L
 	 * The default value of the '{@link #getOperation() <em>Operation</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getOperation()
 	 * @generated
 	 * @ordered
@@ -41,7 +40,6 @@ public class LogicalConstraintImpl extends ConstraintValidationImpl implements L
 	 * The cached value of the '{@link #getOperation() <em>Operation</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getOperation()
 	 * @generated
 	 * @ordered
@@ -51,7 +49,6 @@ public class LogicalConstraintImpl extends ConstraintValidationImpl implements L
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected LogicalConstraintImpl() {
@@ -61,7 +58,6 @@ public class LogicalConstraintImpl extends ConstraintValidationImpl implements L
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -72,7 +68,6 @@ public class LogicalConstraintImpl extends ConstraintValidationImpl implements L
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public LogicalOperator getOperation() {
@@ -82,24 +77,18 @@ public class LogicalConstraintImpl extends ConstraintValidationImpl implements L
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setOperation(LogicalOperator newOperation) {
 		LogicalOperator oldOperation = operation;
-		operation = newOperation == null
-				? OPERATION_EDEFAULT
-				: newOperation;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.LOGICAL_CONSTRAINT__OPERATION, oldOperation, operation));
-		}
+		operation = newOperation == null ? OPERATION_EDEFAULT : newOperation;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.LOGICAL_CONSTRAINT__OPERATION, oldOperation, operation));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -114,14 +103,13 @@ public class LogicalConstraintImpl extends ConstraintValidationImpl implements L
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.LOGICAL_CONSTRAINT__OPERATION:
-				setOperation((LogicalOperator) newValue);
+				setOperation((LogicalOperator)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -130,7 +118,6 @@ public class LogicalConstraintImpl extends ConstraintValidationImpl implements L
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -146,7 +133,6 @@ public class LogicalConstraintImpl extends ConstraintValidationImpl implements L
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -161,14 +147,11 @@ public class LogicalConstraintImpl extends ConstraintValidationImpl implements L
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (operation: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/NullFlavorImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/NullFlavorImpl.java
@@ -27,10 +27,10 @@ import org.openhealthtools.mdht.uml.cda.core.profile.NullFlavorKind;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.NullFlavorImpl#getNullFlavor <em>Null Flavor</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.NullFlavorImpl#getNullFlavor <em>Null Flavor</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class NullFlavorImpl extends PropertyValidationImpl implements NullFlavor {
@@ -38,7 +38,6 @@ public class NullFlavorImpl extends PropertyValidationImpl implements NullFlavor
 	 * The default value of the '{@link #getNullFlavor() <em>Null Flavor</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getNullFlavor()
 	 * @generated
 	 * @ordered
@@ -49,7 +48,6 @@ public class NullFlavorImpl extends PropertyValidationImpl implements NullFlavor
 	 * The cached value of the '{@link #getNullFlavor() <em>Null Flavor</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getNullFlavor()
 	 * @generated
 	 * @ordered
@@ -59,7 +57,6 @@ public class NullFlavorImpl extends PropertyValidationImpl implements NullFlavor
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected NullFlavorImpl() {
@@ -69,7 +66,6 @@ public class NullFlavorImpl extends PropertyValidationImpl implements NullFlavor
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -84,7 +80,6 @@ public class NullFlavorImpl extends PropertyValidationImpl implements NullFlavor
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -119,7 +114,6 @@ public class NullFlavorImpl extends PropertyValidationImpl implements NullFlavor
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -130,7 +124,6 @@ public class NullFlavorImpl extends PropertyValidationImpl implements NullFlavor
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -146,7 +139,6 @@ public class NullFlavorImpl extends PropertyValidationImpl implements NullFlavor
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public NullFlavorKind getNullFlavor() {
@@ -156,31 +148,23 @@ public class NullFlavorImpl extends PropertyValidationImpl implements NullFlavor
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setNullFlavor(NullFlavorKind newNullFlavor) {
 		NullFlavorKind oldNullFlavor = nullFlavor;
-		nullFlavor = newNullFlavor == null
-				? NULL_FLAVOR_EDEFAULT
-				: newNullFlavor;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.NULL_FLAVOR__NULL_FLAVOR, oldNullFlavor, nullFlavor));
-		}
+		nullFlavor = newNullFlavor == null ? NULL_FLAVOR_EDEFAULT : newNullFlavor;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.NULL_FLAVOR__NULL_FLAVOR, oldNullFlavor, nullFlavor));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (nullFlavor: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ParticipationImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ParticipationImpl.java
@@ -29,12 +29,12 @@ import org.openhealthtools.mdht.uml.cda.core.profile.Participation;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ParticipationImpl#getBase_Association <em>Base Association</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ParticipationImpl#getAssociationType <em>Association Type</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ParticipationImpl#getTypeCode <em>Type Code</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ParticipationImpl#getBase_Association <em>Base Association</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ParticipationImpl#getAssociationType <em>Association Type</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ParticipationImpl#getTypeCode <em>Type Code</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ParticipationImpl extends EObjectImpl implements Participation {
@@ -42,7 +42,6 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	 * The cached value of the '{@link #getBase_Association() <em>Base Association</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getBase_Association()
 	 * @generated
 	 * @ordered
@@ -53,7 +52,6 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	 * The cached value of the '{@link #getAssociationType() <em>Association Type</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getAssociationType()
 	 * @generated
 	 * @ordered
@@ -64,7 +62,6 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	 * The cached value of the '{@link #getTypeCode() <em>Type Code</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getTypeCode()
 	 * @generated
 	 * @ordered
@@ -74,7 +71,6 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected ParticipationImpl() {
@@ -84,7 +80,6 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public org.eclipse.uml2.uml.Class basicGetAssociationType() {
@@ -94,7 +89,6 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Association basicGetBase_Association() {
@@ -104,7 +98,6 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EnumerationLiteral basicGetTypeCode() {
@@ -114,26 +107,19 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
 			case CDAPackage.PARTICIPATION__BASE_ASSOCIATION:
-				if (resolve) {
-					return getBase_Association();
-				}
+				if (resolve) return getBase_Association();
 				return basicGetBase_Association();
 			case CDAPackage.PARTICIPATION__ASSOCIATION_TYPE:
-				if (resolve) {
-					return getAssociationType();
-				}
+				if (resolve) return getAssociationType();
 				return basicGetAssociationType();
 			case CDAPackage.PARTICIPATION__TYPE_CODE:
-				if (resolve) {
-					return getTypeCode();
-				}
+				if (resolve) return getTypeCode();
 				return basicGetTypeCode();
 		}
 		return super.eGet(featureID, resolve, coreType);
@@ -142,7 +128,6 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -161,20 +146,19 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.PARTICIPATION__BASE_ASSOCIATION:
-				setBase_Association((Association) newValue);
+				setBase_Association((Association)newValue);
 				return;
 			case CDAPackage.PARTICIPATION__ASSOCIATION_TYPE:
-				setAssociationType((org.eclipse.uml2.uml.Class) newValue);
+				setAssociationType((org.eclipse.uml2.uml.Class)newValue);
 				return;
 			case CDAPackage.PARTICIPATION__TYPE_CODE:
-				setTypeCode((EnumerationLiteral) newValue);
+				setTypeCode((EnumerationLiteral)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -183,7 +167,6 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -194,20 +177,19 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
 			case CDAPackage.PARTICIPATION__BASE_ASSOCIATION:
-				setBase_Association((Association) null);
+				setBase_Association((Association)null);
 				return;
 			case CDAPackage.PARTICIPATION__ASSOCIATION_TYPE:
-				setAssociationType((org.eclipse.uml2.uml.Class) null);
+				setAssociationType((org.eclipse.uml2.uml.Class)null);
 				return;
 			case CDAPackage.PARTICIPATION__TYPE_CODE:
-				setTypeCode((EnumerationLiteral) null);
+				setTypeCode((EnumerationLiteral)null);
 				return;
 		}
 		super.eUnset(featureID);
@@ -216,19 +198,15 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public org.eclipse.uml2.uml.Class getAssociationType() {
 		if (associationType != null && associationType.eIsProxy()) {
-			InternalEObject oldAssociationType = (InternalEObject) associationType;
-			associationType = (org.eclipse.uml2.uml.Class) eResolveProxy(oldAssociationType);
+			InternalEObject oldAssociationType = (InternalEObject)associationType;
+			associationType = (org.eclipse.uml2.uml.Class)eResolveProxy(oldAssociationType);
 			if (associationType != oldAssociationType) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.PARTICIPATION__ASSOCIATION_TYPE, oldAssociationType,
-						associationType));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.PARTICIPATION__ASSOCIATION_TYPE, oldAssociationType, associationType));
 			}
 		}
 		return associationType;
@@ -237,19 +215,15 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Association getBase_Association() {
 		if (base_Association != null && base_Association.eIsProxy()) {
-			InternalEObject oldBase_Association = (InternalEObject) base_Association;
-			base_Association = (Association) eResolveProxy(oldBase_Association);
+			InternalEObject oldBase_Association = (InternalEObject)base_Association;
+			base_Association = (Association)eResolveProxy(oldBase_Association);
 			if (base_Association != oldBase_Association) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.PARTICIPATION__BASE_ASSOCIATION, oldBase_Association,
-						base_Association));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.PARTICIPATION__BASE_ASSOCIATION, oldBase_Association, base_Association));
 			}
 		}
 		return base_Association;
@@ -258,18 +232,15 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EnumerationLiteral getTypeCode() {
 		if (typeCode != null && typeCode.eIsProxy()) {
-			InternalEObject oldTypeCode = (InternalEObject) typeCode;
-			typeCode = (EnumerationLiteral) eResolveProxy(oldTypeCode);
+			InternalEObject oldTypeCode = (InternalEObject)typeCode;
+			typeCode = (EnumerationLiteral)eResolveProxy(oldTypeCode);
 			if (typeCode != oldTypeCode) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.PARTICIPATION__TYPE_CODE, oldTypeCode, typeCode));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.PARTICIPATION__TYPE_CODE, oldTypeCode, typeCode));
 			}
 		}
 		return typeCode;
@@ -278,47 +249,37 @@ public class ParticipationImpl extends EObjectImpl implements Participation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setAssociationType(org.eclipse.uml2.uml.Class newAssociationType) {
 		org.eclipse.uml2.uml.Class oldAssociationType = associationType;
 		associationType = newAssociationType;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.PARTICIPATION__ASSOCIATION_TYPE, oldAssociationType, associationType));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.PARTICIPATION__ASSOCIATION_TYPE, oldAssociationType, associationType));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setBase_Association(Association newBase_Association) {
 		Association oldBase_Association = base_Association;
 		base_Association = newBase_Association;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.PARTICIPATION__BASE_ASSOCIATION, oldBase_Association,
-				base_Association));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.PARTICIPATION__BASE_ASSOCIATION, oldBase_Association, base_Association));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setTypeCode(EnumerationLiteral newTypeCode) {
 		EnumerationLiteral oldTypeCode = typeCode;
 		typeCode = newTypeCode;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.PARTICIPATION__TYPE_CODE, oldTypeCode, typeCode));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.PARTICIPATION__TYPE_CODE, oldTypeCode, typeCode));
 	}
 
 } // ParticipationImpl

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/PropertyValidationImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/PropertyValidationImpl.java
@@ -27,10 +27,10 @@ import org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.PropertyValidationImpl#getBase_Property <em>Base Property</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.PropertyValidationImpl#getBase_Property <em>Base Property</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class PropertyValidationImpl extends ValidationImpl implements PropertyValidation {
@@ -38,7 +38,6 @@ public class PropertyValidationImpl extends ValidationImpl implements PropertyVa
 	 * The cached value of the '{@link #getBase_Property() <em>Base Property</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getBase_Property()
 	 * @generated
 	 * @ordered
@@ -48,7 +47,6 @@ public class PropertyValidationImpl extends ValidationImpl implements PropertyVa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected PropertyValidationImpl() {
@@ -58,7 +56,6 @@ public class PropertyValidationImpl extends ValidationImpl implements PropertyVa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Property basicGetBase_Property() {
@@ -68,16 +65,13 @@ public class PropertyValidationImpl extends ValidationImpl implements PropertyVa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
 			case CDAPackage.PROPERTY_VALIDATION__BASE_PROPERTY:
-				if (resolve) {
-					return getBase_Property();
-				}
+				if (resolve) return getBase_Property();
 				return basicGetBase_Property();
 		}
 		return super.eGet(featureID, resolve, coreType);
@@ -86,7 +80,6 @@ public class PropertyValidationImpl extends ValidationImpl implements PropertyVa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -101,14 +94,13 @@ public class PropertyValidationImpl extends ValidationImpl implements PropertyVa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.PROPERTY_VALIDATION__BASE_PROPERTY:
-				setBase_Property((Property) newValue);
+				setBase_Property((Property)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -117,7 +109,6 @@ public class PropertyValidationImpl extends ValidationImpl implements PropertyVa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -128,14 +119,13 @@ public class PropertyValidationImpl extends ValidationImpl implements PropertyVa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
 			case CDAPackage.PROPERTY_VALIDATION__BASE_PROPERTY:
-				setBase_Property((Property) null);
+				setBase_Property((Property)null);
 				return;
 		}
 		super.eUnset(featureID);
@@ -144,19 +134,15 @@ public class PropertyValidationImpl extends ValidationImpl implements PropertyVa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Property getBase_Property() {
 		if (base_Property != null && base_Property.eIsProxy()) {
-			InternalEObject oldBase_Property = (InternalEObject) base_Property;
-			base_Property = (Property) eResolveProxy(oldBase_Property);
+			InternalEObject oldBase_Property = (InternalEObject)base_Property;
+			base_Property = (Property)eResolveProxy(oldBase_Property);
 			if (base_Property != oldBase_Property) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.PROPERTY_VALIDATION__BASE_PROPERTY, oldBase_Property,
-						base_Property));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.PROPERTY_VALIDATION__BASE_PROPERTY, oldBase_Property, base_Property));
 			}
 		}
 		return base_Property;
@@ -165,16 +151,13 @@ public class PropertyValidationImpl extends ValidationImpl implements PropertyVa
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setBase_Property(Property newBase_Property) {
 		Property oldBase_Property = base_Property;
 		base_Property = newBase_Property;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.PROPERTY_VALIDATION__BASE_PROPERTY, oldBase_Property, base_Property));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.PROPERTY_VALIDATION__BASE_PROPERTY, oldBase_Property, base_Property));
 	}
 
 } // PropertyValidationImpl

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/TextValueImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/TextValueImpl.java
@@ -25,11 +25,11 @@ import org.openhealthtools.mdht.uml.cda.core.profile.TextValue;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.TextValueImpl#getValue <em>Value</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.TextValueImpl#isIgnoreCase <em>Ignore Case</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.TextValueImpl#getValue <em>Value</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.TextValueImpl#isIgnoreCase <em>Ignore Case</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class TextValueImpl extends PropertyValidationImpl implements TextValue {
@@ -37,7 +37,6 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getValue()
 	 * @generated
 	 * @ordered
@@ -48,7 +47,6 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getValue()
 	 * @generated
 	 * @ordered
@@ -59,7 +57,6 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	 * The default value of the '{@link #isIgnoreCase() <em>Ignore Case</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isIgnoreCase()
 	 * @generated
 	 * @ordered
@@ -70,7 +67,6 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	 * The cached value of the '{@link #isIgnoreCase() <em>Ignore Case</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isIgnoreCase()
 	 * @generated
 	 * @ordered
@@ -80,7 +76,6 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected TextValueImpl() {
@@ -90,7 +85,6 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -107,16 +101,13 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
 			case CDAPackage.TEXT_VALUE__VALUE:
-				return VALUE_EDEFAULT == null
-						? value != null
-						: !VALUE_EDEFAULT.equals(value);
+				return VALUE_EDEFAULT == null ? value != null : !VALUE_EDEFAULT.equals(value);
 			case CDAPackage.TEXT_VALUE__IGNORE_CASE:
 				return ignoreCase != IGNORE_CASE_EDEFAULT;
 		}
@@ -126,17 +117,16 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.TEXT_VALUE__VALUE:
-				setValue((String) newValue);
+				setValue((String)newValue);
 				return;
 			case CDAPackage.TEXT_VALUE__IGNORE_CASE:
-				setIgnoreCase((Boolean) newValue);
+				setIgnoreCase((Boolean)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -145,7 +135,6 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -156,7 +145,6 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -175,7 +163,6 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getValue() {
@@ -185,7 +172,6 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public boolean isIgnoreCase() {
@@ -195,43 +181,35 @@ public class TextValueImpl extends PropertyValidationImpl implements TextValue {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setIgnoreCase(boolean newIgnoreCase) {
 		boolean oldIgnoreCase = ignoreCase;
 		ignoreCase = newIgnoreCase;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.TEXT_VALUE__IGNORE_CASE, oldIgnoreCase, ignoreCase));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.TEXT_VALUE__IGNORE_CASE, oldIgnoreCase, ignoreCase));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setValue(String newValue) {
 		String oldValue = value;
 		value = newValue;
-		if (eNotificationRequired()) {
+		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.TEXT_VALUE__VALUE, oldValue, value));
-		}
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (value: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/UnimplementableImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/UnimplementableImpl.java
@@ -22,10 +22,10 @@ import org.openhealthtools.mdht.uml.cda.core.profile.Unimplementable;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.UnimplementableImpl#getBase_Constraint <em>Base Constraint</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.UnimplementableImpl#getBase_Constraint <em>Base Constraint</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class UnimplementableImpl extends EObjectImpl implements Unimplementable {
@@ -33,7 +33,6 @@ public class UnimplementableImpl extends EObjectImpl implements Unimplementable 
 	 * The cached value of the '{@link #getBase_Constraint() <em>Base Constraint</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getBase_Constraint()
 	 * @generated
 	 * @ordered
@@ -43,7 +42,6 @@ public class UnimplementableImpl extends EObjectImpl implements Unimplementable 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected UnimplementableImpl() {
@@ -53,7 +51,6 @@ public class UnimplementableImpl extends EObjectImpl implements Unimplementable 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -64,19 +61,15 @@ public class UnimplementableImpl extends EObjectImpl implements Unimplementable 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Constraint getBase_Constraint() {
 		if (base_Constraint != null && base_Constraint.eIsProxy()) {
-			InternalEObject oldBase_Constraint = (InternalEObject) base_Constraint;
-			base_Constraint = (Constraint) eResolveProxy(oldBase_Constraint);
+			InternalEObject oldBase_Constraint = (InternalEObject)base_Constraint;
+			base_Constraint = (Constraint)eResolveProxy(oldBase_Constraint);
 			if (base_Constraint != oldBase_Constraint) {
-				if (eNotificationRequired()) {
-					eNotify(new ENotificationImpl(
-						this, Notification.RESOLVE, CDAPackage.UNIMPLEMENTABLE__BASE_CONSTRAINT, oldBase_Constraint,
-						base_Constraint));
-				}
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, CDAPackage.UNIMPLEMENTABLE__BASE_CONSTRAINT, oldBase_Constraint, base_Constraint));
 			}
 		}
 		return base_Constraint;
@@ -85,7 +78,6 @@ public class UnimplementableImpl extends EObjectImpl implements Unimplementable 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public Constraint basicGetBase_Constraint() {
@@ -95,32 +87,25 @@ public class UnimplementableImpl extends EObjectImpl implements Unimplementable 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setBase_Constraint(Constraint newBase_Constraint) {
 		Constraint oldBase_Constraint = base_Constraint;
 		base_Constraint = newBase_Constraint;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.UNIMPLEMENTABLE__BASE_CONSTRAINT, oldBase_Constraint,
-				base_Constraint));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.UNIMPLEMENTABLE__BASE_CONSTRAINT, oldBase_Constraint, base_Constraint));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
 			case CDAPackage.UNIMPLEMENTABLE__BASE_CONSTRAINT:
-				if (resolve) {
-					return getBase_Constraint();
-				}
+				if (resolve) return getBase_Constraint();
 				return basicGetBase_Constraint();
 		}
 		return super.eGet(featureID, resolve, coreType);
@@ -129,14 +114,13 @@ public class UnimplementableImpl extends EObjectImpl implements Unimplementable 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.UNIMPLEMENTABLE__BASE_CONSTRAINT:
-				setBase_Constraint((Constraint) newValue);
+				setBase_Constraint((Constraint)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -145,14 +129,13 @@ public class UnimplementableImpl extends EObjectImpl implements Unimplementable 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
 			case CDAPackage.UNIMPLEMENTABLE__BASE_CONSTRAINT:
-				setBase_Constraint((Constraint) null);
+				setBase_Constraint((Constraint)null);
 				return;
 		}
 		super.eUnset(featureID);
@@ -161,7 +144,6 @@ public class UnimplementableImpl extends EObjectImpl implements Unimplementable 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ValidationImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ValidationImpl.java
@@ -32,13 +32,13 @@ import org.openhealthtools.mdht.uml.cda.core.profile.Validation;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValidationImpl#getMessage <em>Message</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValidationImpl#getSeverity <em>Severity</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValidationImpl#getRuleId <em>Rule Id</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValidationImpl#isMandatory <em>Mandatory</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValidationImpl#getMessage <em>Message</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValidationImpl#getSeverity <em>Severity</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValidationImpl#getRuleId <em>Rule Id</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValidationImpl#isMandatory <em>Mandatory</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public abstract class ValidationImpl extends EObjectImpl implements Validation {
@@ -46,7 +46,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	 * The default value of the '{@link #getMessage() <em>Message</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getMessage()
 	 * @generated
 	 * @ordered
@@ -57,7 +56,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	 * The cached value of the '{@link #getMessage() <em>Message</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getMessage()
 	 * @generated
 	 * @ordered
@@ -68,7 +66,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	 * The default value of the '{@link #getSeverity() <em>Severity</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getSeverity()
 	 * @generated
 	 * @ordered
@@ -79,7 +76,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	 * The cached value of the '{@link #getSeverity() <em>Severity</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getSeverity()
 	 * @generated
 	 * @ordered
@@ -90,7 +86,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	 * The cached value of the '{@link #getRuleId() <em>Rule Id</em>}' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getRuleId()
 	 * @generated
 	 * @ordered
@@ -101,7 +96,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	 * The default value of the '{@link #isMandatory() <em>Mandatory</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isMandatory()
 	 * @generated
 	 * @ordered
@@ -112,7 +106,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	 * The cached value of the '{@link #isMandatory() <em>Mandatory</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isMandatory()
 	 * @generated
 	 * @ordered
@@ -122,7 +115,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected ValidationImpl() {
@@ -132,7 +124,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -153,16 +144,13 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
 			case CDAPackage.VALIDATION__MESSAGE:
-				return MESSAGE_EDEFAULT == null
-						? message != null
-						: !MESSAGE_EDEFAULT.equals(message);
+				return MESSAGE_EDEFAULT == null ? message != null : !MESSAGE_EDEFAULT.equals(message);
 			case CDAPackage.VALIDATION__SEVERITY:
 				return severity != SEVERITY_EDEFAULT;
 			case CDAPackage.VALIDATION__RULE_ID:
@@ -207,7 +195,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -218,7 +205,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -243,7 +229,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getMessage() {
@@ -253,7 +238,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EList<String> getRuleId() {
@@ -266,7 +250,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public SeverityKind getSeverity() {
@@ -276,7 +259,6 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public boolean isMandatory() {
@@ -286,60 +268,47 @@ public abstract class ValidationImpl extends EObjectImpl implements Validation {
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setMandatory(boolean newMandatory) {
 		boolean oldMandatory = mandatory;
 		mandatory = newMandatory;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.VALIDATION__MANDATORY, oldMandatory, mandatory));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.VALIDATION__MANDATORY, oldMandatory, mandatory));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setMessage(String newMessage) {
 		String oldMessage = message;
 		message = newMessage;
-		if (eNotificationRequired()) {
+		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.VALIDATION__MESSAGE, oldMessage, message));
-		}
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setSeverity(SeverityKind newSeverity) {
 		SeverityKind oldSeverity = severity;
-		severity = newSeverity == null
-				? SEVERITY_EDEFAULT
-				: newSeverity;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.VALIDATION__SEVERITY, oldSeverity, severity));
-		}
+		severity = newSeverity == null ? SEVERITY_EDEFAULT : newSeverity;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.VALIDATION__SEVERITY, oldSeverity, severity));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (message: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ValueSetConstraintImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/ValueSetConstraintImpl.java
@@ -31,13 +31,13 @@ import org.openhealthtools.mdht.uml.cda.core.profile.ValueSetConstraint;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl#getMessage <em>Message</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl#getSeverity <em>Severity</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl#getRuleId <em>Rule Id</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl#isMandatory <em>Mandatory</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl#getMessage <em>Message</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl#getSeverity <em>Severity</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl#getRuleId <em>Rule Id</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.ValueSetConstraintImpl#isMandatory <em>Mandatory</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.core.profile.impl.ValueSetConstraintImpl
@@ -46,7 +46,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	 * The default value of the '{@link #getMessage() <em>Message</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getMessage()
 	 * @generated
 	 * @ordered
@@ -57,7 +56,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	 * The cached value of the '{@link #getMessage() <em>Message</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getMessage()
 	 * @generated
 	 * @ordered
@@ -68,7 +66,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	 * The default value of the '{@link #getSeverity() <em>Severity</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getSeverity()
 	 * @generated
 	 * @ordered
@@ -79,7 +76,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	 * The cached value of the '{@link #getSeverity() <em>Severity</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getSeverity()
 	 * @generated
 	 * @ordered
@@ -90,7 +86,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	 * The cached value of the '{@link #getRuleId() <em>Rule Id</em>}' attribute list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getRuleId()
 	 * @generated
 	 * @ordered
@@ -101,7 +96,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	 * The default value of the '{@link #isMandatory() <em>Mandatory</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isMandatory()
 	 * @generated
 	 * @ordered
@@ -112,7 +106,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	 * The cached value of the '{@link #isMandatory() <em>Mandatory</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #isMandatory()
 	 * @generated
 	 * @ordered
@@ -122,7 +115,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected ValueSetConstraintImpl() {
@@ -132,23 +124,17 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public int eBaseStructuralFeatureID(int derivedFeatureID, Class<?> baseClass) {
 		if (baseClass == Validation.class) {
 			switch (derivedFeatureID) {
-				case CDAPackage.VALUE_SET_CONSTRAINT__MESSAGE:
-					return CDAPackage.VALIDATION__MESSAGE;
-				case CDAPackage.VALUE_SET_CONSTRAINT__SEVERITY:
-					return CDAPackage.VALIDATION__SEVERITY;
-				case CDAPackage.VALUE_SET_CONSTRAINT__RULE_ID:
-					return CDAPackage.VALIDATION__RULE_ID;
-				case CDAPackage.VALUE_SET_CONSTRAINT__MANDATORY:
-					return CDAPackage.VALIDATION__MANDATORY;
-				default:
-					return -1;
+				case CDAPackage.VALUE_SET_CONSTRAINT__MESSAGE: return CDAPackage.VALIDATION__MESSAGE;
+				case CDAPackage.VALUE_SET_CONSTRAINT__SEVERITY: return CDAPackage.VALIDATION__SEVERITY;
+				case CDAPackage.VALUE_SET_CONSTRAINT__RULE_ID: return CDAPackage.VALIDATION__RULE_ID;
+				case CDAPackage.VALUE_SET_CONSTRAINT__MANDATORY: return CDAPackage.VALIDATION__MANDATORY;
+				default: return -1;
 			}
 		}
 		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
@@ -157,23 +143,17 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public int eDerivedStructuralFeatureID(int baseFeatureID, Class<?> baseClass) {
 		if (baseClass == Validation.class) {
 			switch (baseFeatureID) {
-				case CDAPackage.VALIDATION__MESSAGE:
-					return CDAPackage.VALUE_SET_CONSTRAINT__MESSAGE;
-				case CDAPackage.VALIDATION__SEVERITY:
-					return CDAPackage.VALUE_SET_CONSTRAINT__SEVERITY;
-				case CDAPackage.VALIDATION__RULE_ID:
-					return CDAPackage.VALUE_SET_CONSTRAINT__RULE_ID;
-				case CDAPackage.VALIDATION__MANDATORY:
-					return CDAPackage.VALUE_SET_CONSTRAINT__MANDATORY;
-				default:
-					return -1;
+				case CDAPackage.VALIDATION__MESSAGE: return CDAPackage.VALUE_SET_CONSTRAINT__MESSAGE;
+				case CDAPackage.VALIDATION__SEVERITY: return CDAPackage.VALUE_SET_CONSTRAINT__SEVERITY;
+				case CDAPackage.VALIDATION__RULE_ID: return CDAPackage.VALUE_SET_CONSTRAINT__RULE_ID;
+				case CDAPackage.VALIDATION__MANDATORY: return CDAPackage.VALUE_SET_CONSTRAINT__MANDATORY;
+				default: return -1;
 			}
 		}
 		return super.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
@@ -182,7 +162,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -203,16 +182,13 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
 			case CDAPackage.VALUE_SET_CONSTRAINT__MESSAGE:
-				return MESSAGE_EDEFAULT == null
-						? message != null
-						: !MESSAGE_EDEFAULT.equals(message);
+				return MESSAGE_EDEFAULT == null ? message != null : !MESSAGE_EDEFAULT.equals(message);
 			case CDAPackage.VALUE_SET_CONSTRAINT__SEVERITY:
 				return severity != SEVERITY_EDEFAULT;
 			case CDAPackage.VALUE_SET_CONSTRAINT__RULE_ID:
@@ -226,7 +202,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -234,17 +209,17 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.VALUE_SET_CONSTRAINT__MESSAGE:
-				setMessage((String) newValue);
+				setMessage((String)newValue);
 				return;
 			case CDAPackage.VALUE_SET_CONSTRAINT__SEVERITY:
-				setSeverity((SeverityKind) newValue);
+				setSeverity((SeverityKind)newValue);
 				return;
 			case CDAPackage.VALUE_SET_CONSTRAINT__RULE_ID:
 				getRuleId().clear();
-				getRuleId().addAll((Collection<? extends String>) newValue);
+				getRuleId().addAll((Collection<? extends String>)newValue);
 				return;
 			case CDAPackage.VALUE_SET_CONSTRAINT__MANDATORY:
-				setMandatory((Boolean) newValue);
+				setMandatory((Boolean)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -253,7 +228,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -264,7 +238,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -289,7 +262,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getMessage() {
@@ -299,7 +271,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public EList<String> getRuleId() {
@@ -312,7 +283,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public SeverityKind getSeverity() {
@@ -322,7 +292,6 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public boolean isMandatory() {
@@ -332,61 +301,47 @@ public class ValueSetConstraintImpl extends org.openhealthtools.mdht.uml.term.co
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setMandatory(boolean newMandatory) {
 		boolean oldMandatory = mandatory;
 		mandatory = newMandatory;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.VALUE_SET_CONSTRAINT__MANDATORY, oldMandatory, mandatory));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.VALUE_SET_CONSTRAINT__MANDATORY, oldMandatory, mandatory));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setMessage(String newMessage) {
 		String oldMessage = message;
 		message = newMessage;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.VALUE_SET_CONSTRAINT__MESSAGE, oldMessage, message));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.VALUE_SET_CONSTRAINT__MESSAGE, oldMessage, message));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setSeverity(SeverityKind newSeverity) {
 		SeverityKind oldSeverity = severity;
-		severity = newSeverity == null
-				? SEVERITY_EDEFAULT
-				: newSeverity;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.VALUE_SET_CONSTRAINT__SEVERITY, oldSeverity, severity));
-		}
+		severity = newSeverity == null ? SEVERITY_EDEFAULT : newSeverity;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.VALUE_SET_CONSTRAINT__SEVERITY, oldSeverity, severity));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (message: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/VocabSpecificationImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/impl/VocabSpecificationImpl.java
@@ -25,14 +25,14 @@ import org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification;
  * <p>
  * The following features are implemented:
  * <ul>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl#getCode <em>Code</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl#getCodeSystem <em>Code System</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl#getCodeSystemName <em>Code System Name</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl#getCodeSystemVersion <em>Code System Version</em>}</li>
- * <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl#getDisplayName <em>Display Name</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl#getCode <em>Code</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl#getCodeSystem <em>Code System</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl#getCodeSystemName <em>Code System Name</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl#getCodeSystemVersion <em>Code System Version</em>}</li>
+ *   <li>{@link org.openhealthtools.mdht.uml.cda.core.profile.impl.VocabSpecificationImpl#getDisplayName <em>Display Name</em>}</li>
  * </ul>
  * </p>
- * 
+ *
  * @generated
  */
 public class VocabSpecificationImpl extends PropertyValidationImpl implements VocabSpecification {
@@ -40,7 +40,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	 * The default value of the '{@link #getCode() <em>Code</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getCode()
 	 * @generated
 	 * @ordered
@@ -51,7 +50,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	 * The cached value of the '{@link #getCode() <em>Code</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getCode()
 	 * @generated
 	 * @ordered
@@ -62,7 +60,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	 * The default value of the '{@link #getCodeSystem() <em>Code System</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getCodeSystem()
 	 * @generated
 	 * @ordered
@@ -73,7 +70,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	 * The cached value of the '{@link #getCodeSystem() <em>Code System</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getCodeSystem()
 	 * @generated
 	 * @ordered
@@ -84,7 +80,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	 * The default value of the '{@link #getCodeSystemName() <em>Code System Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getCodeSystemName()
 	 * @generated
 	 * @ordered
@@ -95,7 +90,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	 * The cached value of the '{@link #getCodeSystemName() <em>Code System Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getCodeSystemName()
 	 * @generated
 	 * @ordered
@@ -106,7 +100,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	 * The default value of the '{@link #getCodeSystemVersion() <em>Code System Version</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getCodeSystemVersion()
 	 * @generated
 	 * @ordered
@@ -117,7 +110,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	 * The cached value of the '{@link #getCodeSystemVersion() <em>Code System Version</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getCodeSystemVersion()
 	 * @generated
 	 * @ordered
@@ -128,7 +120,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	 * The default value of the '{@link #getDisplayName() <em>Display Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getDisplayName()
 	 * @generated
 	 * @ordered
@@ -139,7 +130,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	 * The cached value of the '{@link #getDisplayName() <em>Display Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @see #getDisplayName()
 	 * @generated
 	 * @ordered
@@ -149,7 +139,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected VocabSpecificationImpl() {
@@ -159,7 +148,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -182,32 +170,21 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
 			case CDAPackage.VOCAB_SPECIFICATION__CODE:
-				return CODE_EDEFAULT == null
-						? code != null
-						: !CODE_EDEFAULT.equals(code);
+				return CODE_EDEFAULT == null ? code != null : !CODE_EDEFAULT.equals(code);
 			case CDAPackage.VOCAB_SPECIFICATION__CODE_SYSTEM:
-				return CODE_SYSTEM_EDEFAULT == null
-						? codeSystem != null
-						: !CODE_SYSTEM_EDEFAULT.equals(codeSystem);
+				return CODE_SYSTEM_EDEFAULT == null ? codeSystem != null : !CODE_SYSTEM_EDEFAULT.equals(codeSystem);
 			case CDAPackage.VOCAB_SPECIFICATION__CODE_SYSTEM_NAME:
-				return CODE_SYSTEM_NAME_EDEFAULT == null
-						? codeSystemName != null
-						: !CODE_SYSTEM_NAME_EDEFAULT.equals(codeSystemName);
+				return CODE_SYSTEM_NAME_EDEFAULT == null ? codeSystemName != null : !CODE_SYSTEM_NAME_EDEFAULT.equals(codeSystemName);
 			case CDAPackage.VOCAB_SPECIFICATION__CODE_SYSTEM_VERSION:
-				return CODE_SYSTEM_VERSION_EDEFAULT == null
-						? codeSystemVersion != null
-						: !CODE_SYSTEM_VERSION_EDEFAULT.equals(codeSystemVersion);
+				return CODE_SYSTEM_VERSION_EDEFAULT == null ? codeSystemVersion != null : !CODE_SYSTEM_VERSION_EDEFAULT.equals(codeSystemVersion);
 			case CDAPackage.VOCAB_SPECIFICATION__DISPLAY_NAME:
-				return DISPLAY_NAME_EDEFAULT == null
-						? displayName != null
-						: !DISPLAY_NAME_EDEFAULT.equals(displayName);
+				return DISPLAY_NAME_EDEFAULT == null ? displayName != null : !DISPLAY_NAME_EDEFAULT.equals(displayName);
 		}
 		return super.eIsSet(featureID);
 	}
@@ -215,26 +192,25 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
 			case CDAPackage.VOCAB_SPECIFICATION__CODE:
-				setCode((String) newValue);
+				setCode((String)newValue);
 				return;
 			case CDAPackage.VOCAB_SPECIFICATION__CODE_SYSTEM:
-				setCodeSystem((String) newValue);
+				setCodeSystem((String)newValue);
 				return;
 			case CDAPackage.VOCAB_SPECIFICATION__CODE_SYSTEM_NAME:
-				setCodeSystemName((String) newValue);
+				setCodeSystemName((String)newValue);
 				return;
 			case CDAPackage.VOCAB_SPECIFICATION__CODE_SYSTEM_VERSION:
-				setCodeSystemVersion((String) newValue);
+				setCodeSystemVersion((String)newValue);
 				return;
 			case CDAPackage.VOCAB_SPECIFICATION__DISPLAY_NAME:
-				setDisplayName((String) newValue);
+				setDisplayName((String)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -243,7 +219,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -254,7 +229,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
@@ -282,7 +256,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getCode() {
@@ -292,7 +265,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getCodeSystem() {
@@ -302,7 +274,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getCodeSystemName() {
@@ -312,7 +283,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getCodeSystemVersion() {
@@ -322,7 +292,6 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public String getDisplayName() {
@@ -332,90 +301,71 @@ public class VocabSpecificationImpl extends PropertyValidationImpl implements Vo
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setCode(String newCode) {
 		String oldCode = code;
 		code = newCode;
-		if (eNotificationRequired()) {
+		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.VOCAB_SPECIFICATION__CODE, oldCode, code));
-		}
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setCodeSystem(String newCodeSystem) {
 		String oldCodeSystem = codeSystem;
 		codeSystem = newCodeSystem;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.VOCAB_SPECIFICATION__CODE_SYSTEM, oldCodeSystem, codeSystem));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.VOCAB_SPECIFICATION__CODE_SYSTEM, oldCodeSystem, codeSystem));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setCodeSystemName(String newCodeSystemName) {
 		String oldCodeSystemName = codeSystemName;
 		codeSystemName = newCodeSystemName;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.VOCAB_SPECIFICATION__CODE_SYSTEM_NAME, oldCodeSystemName,
-				codeSystemName));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.VOCAB_SPECIFICATION__CODE_SYSTEM_NAME, oldCodeSystemName, codeSystemName));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setCodeSystemVersion(String newCodeSystemVersion) {
 		String oldCodeSystemVersion = codeSystemVersion;
 		codeSystemVersion = newCodeSystemVersion;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.VOCAB_SPECIFICATION__CODE_SYSTEM_VERSION, oldCodeSystemVersion,
-				codeSystemVersion));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.VOCAB_SPECIFICATION__CODE_SYSTEM_VERSION, oldCodeSystemVersion, codeSystemVersion));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public void setDisplayName(String newDisplayName) {
 		String oldDisplayName = displayName;
 		displayName = newDisplayName;
-		if (eNotificationRequired()) {
-			eNotify(new ENotificationImpl(
-				this, Notification.SET, CDAPackage.VOCAB_SPECIFICATION__DISPLAY_NAME, oldDisplayName, displayName));
-		}
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CDAPackage.VOCAB_SPECIFICATION__DISPLAY_NAME, oldDisplayName, displayName));
 	}
 
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) {
-			return super.toString();
-		}
+		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (code: ");

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/util/CDAAdapterFactory.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/util/CDAAdapterFactory.java
@@ -42,7 +42,6 @@ import org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification;
  * The <b>Adapter Factory</b> for the model.
  * It provides an adapter <code>createXXX</code> method for each class of the model.
  * <!-- end-user-doc -->
- * 
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage
  * @generated
  */
@@ -51,7 +50,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * The cached model package.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected static CDAPackage modelPackage;
@@ -60,144 +58,115 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * The switch that delegates to the <code>createXXX</code> methods.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected CDASwitch<Adapter> modelSwitch = new CDASwitch<Adapter>() {
-		@Override
-		public Adapter caseEntry(Entry object) {
-			return createEntryAdapter();
-		}
-
-		@Override
-		public Adapter caseAssociationValidation(AssociationValidation object) {
-			return createAssociationValidationAdapter();
-		}
-
-		@Override
-		public Adapter caseValidation(Validation object) {
-			return createValidationAdapter();
-		}
-
-		@Override
-		public Adapter caseEntryRelationship(EntryRelationship object) {
-			return createEntryRelationshipAdapter();
-		}
-
-		@Override
-		public Adapter caseCodegenSupport(CodegenSupport object) {
-			return createCodegenSupportAdapter();
-		}
-
-		@Override
-		public Adapter casePropertyValidation(PropertyValidation object) {
-			return createPropertyValidationAdapter();
-		}
-
-		@Override
-		public Adapter caseClassValidation(ClassValidation object) {
-			return createClassValidationAdapter();
-		}
-
-		@Override
-		public Adapter caseVocabSpecification(VocabSpecification object) {
-			return createVocabSpecificationAdapter();
-		}
-
-		@Override
-		public Adapter caseNullFlavor(NullFlavor object) {
-			return createNullFlavorAdapter();
-		}
-
-		@Override
-		public Adapter caseTextValue(TextValue object) {
-			return createTextValueAdapter();
-		}
-
-		@Override
-		public Adapter caseCDATemplate(CDATemplate object) {
-			return createCDATemplateAdapter();
-		}
-
-		@Override
-		public Adapter caseConstraintValidation(ConstraintValidation object) {
-			return createConstraintValidationAdapter();
-		}
-
-		@Override
-		public Adapter caseConformsTo(ConformsTo object) {
-			return createConformsToAdapter();
-		}
-
-		@Override
-		public Adapter caseConceptDomainConstraint(ConceptDomainConstraint object) {
-			return createConceptDomainConstraintAdapter();
-		}
-
-		@Override
-		public Adapter caseCodeSystemConstraint(CodeSystemConstraint object) {
-			return createCodeSystemConstraintAdapter();
-		}
-
-		@Override
-		public Adapter caseValueSetConstraint(ValueSetConstraint object) {
-			return createValueSetConstraintAdapter();
-		}
-
-		@Override
-		public Adapter caseActRelationship(ActRelationship object) {
-			return createActRelationshipAdapter();
-		}
-
-		@Override
-		public Adapter caseParticipation(Participation object) {
-			return createParticipationAdapter();
-		}
-
-		@Override
-		public Adapter caseLogicalConstraint(LogicalConstraint object) {
-			return createLogicalConstraintAdapter();
-		}
-
-		@Override
-		public Adapter caseInline(Inline object) {
-			return createInlineAdapter();
-		}
-
-		@Override
-		public Adapter caseUnimplementable(Unimplementable object) {
-			return createUnimplementableAdapter();
-		}
-
-		@Override
-		public Adapter caseTerm_ConceptDomainConstraint(
-				org.openhealthtools.mdht.uml.term.core.profile.ConceptDomainConstraint object) {
-			return createTerm_ConceptDomainConstraintAdapter();
-		}
-
-		@Override
-		public Adapter caseTerm_CodeSystemConstraint(
-				org.openhealthtools.mdht.uml.term.core.profile.CodeSystemConstraint object) {
-			return createTerm_CodeSystemConstraintAdapter();
-		}
-
-		@Override
-		public Adapter caseTerm_ValueSetConstraint(
-				org.openhealthtools.mdht.uml.term.core.profile.ValueSetConstraint object) {
-			return createTerm_ValueSetConstraintAdapter();
-		}
-
-		@Override
-		public Adapter defaultCase(EObject object) {
-			return createEObjectAdapter();
-		}
-	};
+			@Override
+			public Adapter caseEntry(Entry object) {
+				return createEntryAdapter();
+			}
+			@Override
+			public Adapter caseAssociationValidation(AssociationValidation object) {
+				return createAssociationValidationAdapter();
+			}
+			@Override
+			public Adapter caseValidation(Validation object) {
+				return createValidationAdapter();
+			}
+			@Override
+			public Adapter caseEntryRelationship(EntryRelationship object) {
+				return createEntryRelationshipAdapter();
+			}
+			@Override
+			public Adapter caseCodegenSupport(CodegenSupport object) {
+				return createCodegenSupportAdapter();
+			}
+			@Override
+			public Adapter casePropertyValidation(PropertyValidation object) {
+				return createPropertyValidationAdapter();
+			}
+			@Override
+			public Adapter caseClassValidation(ClassValidation object) {
+				return createClassValidationAdapter();
+			}
+			@Override
+			public Adapter caseVocabSpecification(VocabSpecification object) {
+				return createVocabSpecificationAdapter();
+			}
+			@Override
+			public Adapter caseNullFlavor(NullFlavor object) {
+				return createNullFlavorAdapter();
+			}
+			@Override
+			public Adapter caseTextValue(TextValue object) {
+				return createTextValueAdapter();
+			}
+			@Override
+			public Adapter caseCDATemplate(CDATemplate object) {
+				return createCDATemplateAdapter();
+			}
+			@Override
+			public Adapter caseConstraintValidation(ConstraintValidation object) {
+				return createConstraintValidationAdapter();
+			}
+			@Override
+			public Adapter caseConformsTo(ConformsTo object) {
+				return createConformsToAdapter();
+			}
+			@Override
+			public Adapter caseConceptDomainConstraint(ConceptDomainConstraint object) {
+				return createConceptDomainConstraintAdapter();
+			}
+			@Override
+			public Adapter caseCodeSystemConstraint(CodeSystemConstraint object) {
+				return createCodeSystemConstraintAdapter();
+			}
+			@Override
+			public Adapter caseValueSetConstraint(ValueSetConstraint object) {
+				return createValueSetConstraintAdapter();
+			}
+			@Override
+			public Adapter caseActRelationship(ActRelationship object) {
+				return createActRelationshipAdapter();
+			}
+			@Override
+			public Adapter caseParticipation(Participation object) {
+				return createParticipationAdapter();
+			}
+			@Override
+			public Adapter caseLogicalConstraint(LogicalConstraint object) {
+				return createLogicalConstraintAdapter();
+			}
+			@Override
+			public Adapter caseInline(Inline object) {
+				return createInlineAdapter();
+			}
+			@Override
+			public Adapter caseUnimplementable(Unimplementable object) {
+				return createUnimplementableAdapter();
+			}
+			@Override
+			public Adapter caseTerm_ConceptDomainConstraint(org.openhealthtools.mdht.uml.term.core.profile.ConceptDomainConstraint object) {
+				return createTerm_ConceptDomainConstraintAdapter();
+			}
+			@Override
+			public Adapter caseTerm_CodeSystemConstraint(org.openhealthtools.mdht.uml.term.core.profile.CodeSystemConstraint object) {
+				return createTerm_CodeSystemConstraintAdapter();
+			}
+			@Override
+			public Adapter caseTerm_ValueSetConstraint(org.openhealthtools.mdht.uml.term.core.profile.ValueSetConstraint object) {
+				return createTerm_ValueSetConstraintAdapter();
+			}
+			@Override
+			public Adapter defaultCase(EObject object) {
+				return createEObjectAdapter();
+			}
+		};
 
 	/**
 	 * Creates an instance of the adapter factory.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public CDAAdapterFactory() {
@@ -212,7 +181,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ActRelationship
 	 * @generated
@@ -225,25 +193,21 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * Creates an adapter for the <code>target</code>.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param target
-	 *            the object to adapt.
+	 * @param target the object to adapt.
 	 * @return the adapter for the <code>target</code>.
 	 * @generated
 	 */
 	@Override
 	public Adapter createAdapter(Notifier target) {
-		return modelSwitch.doSwitch((EObject) target);
+		return modelSwitch.doSwitch((EObject)target);
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation
-	 * <em>Association Validation</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation <em>Association Validation</em>}'.
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.AssociationValidation
 	 * @generated
@@ -258,7 +222,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CDATemplate
 	 * @generated
@@ -273,7 +236,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ClassValidation
 	 * @generated
@@ -288,7 +250,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CodegenSupport
 	 * @generated
@@ -298,13 +259,11 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodeSystemConstraint
-	 * <em>Code System Constraint</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.CodeSystemConstraint <em>Code System Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.CodeSystemConstraint
 	 * @generated
@@ -314,13 +273,11 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConceptDomainConstraint
-	 * <em>Concept Domain Constraint</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConceptDomainConstraint <em>Concept Domain Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ConceptDomainConstraint
 	 * @generated
@@ -335,7 +292,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ConformsTo
 	 * @generated
@@ -345,13 +301,11 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation
-	 * <em>Constraint Validation</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation <em>Constraint Validation</em>}'.
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ConstraintValidation
 	 * @generated
@@ -366,7 +320,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Entry
 	 * @generated
@@ -376,13 +329,11 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship
-	 * <em>Entry Relationship</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship <em>Entry Relationship</em>}'.
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship
 	 * @generated
@@ -396,7 +347,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @generated
 	 */
@@ -410,7 +360,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.NullFlavor
 	 * @generated
@@ -425,7 +374,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Participation
 	 * @generated
@@ -435,13 +383,11 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.LogicalConstraint
-	 * <em>Logical Constraint</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.LogicalConstraint <em>Logical Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.LogicalConstraint
 	 * @generated
@@ -456,7 +402,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Inline
 	 * @generated
@@ -471,7 +416,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Unimplementable
 	 * @generated
@@ -481,13 +425,11 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation
-	 * <em>Property Validation</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation <em>Property Validation</em>}'.
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.PropertyValidation
 	 * @generated
@@ -497,13 +439,11 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.term.core.profile.CodeSystemConstraint
-	 * <em>Code System Constraint</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.term.core.profile.CodeSystemConstraint <em>Code System Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.term.core.profile.CodeSystemConstraint
 	 * @generated
@@ -513,13 +453,11 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.term.core.profile.ConceptDomainConstraint
-	 * <em>Concept Domain Constraint</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.term.core.profile.ConceptDomainConstraint <em>Concept Domain Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.term.core.profile.ConceptDomainConstraint
 	 * @generated
@@ -529,13 +467,11 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.term.core.profile.ValueSetConstraint
-	 * <em>Value Set Constraint</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.term.core.profile.ValueSetConstraint <em>Value Set Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.term.core.profile.ValueSetConstraint
 	 * @generated
@@ -550,7 +486,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.TextValue
 	 * @generated
@@ -565,7 +500,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.Validation
 	 * @generated
@@ -575,13 +509,11 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ValueSetConstraint
-	 * <em>Value Set Constraint</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.ValueSetConstraint <em>Value Set Constraint</em>}'.
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.ValueSetConstraint
 	 * @generated
@@ -591,13 +523,11 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification
-	 * <em>Vocab Specification</em>}'.
+	 * Creates a new adapter for an object of class '{@link org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification <em>Vocab Specification</em>}'.
 	 * <!-- begin-user-doc -->
 	 * This default implementation returns null so that we can easily ignore cases;
 	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the new adapter.
 	 * @see org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification
 	 * @generated
@@ -611,7 +541,6 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 	 * <!-- begin-user-doc -->
 	 * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return whether this factory is applicable for the type of the object.
 	 * @generated
 	 */
@@ -621,7 +550,7 @@ public class CDAAdapterFactory extends AdapterFactoryImpl {
 			return true;
 		}
 		if (object instanceof EObject) {
-			return ((EObject) object).eClass().getEPackage() == modelPackage;
+			return ((EObject)object).eClass().getEPackage() == modelPackage;
 		}
 		return false;
 	}

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/util/CDAResourceFactoryImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/util/CDAResourceFactoryImpl.java
@@ -14,7 +14,6 @@ import org.eclipse.emf.ecore.xmi.XMLResource;
  * <!-- begin-user-doc -->
  * The <b>Resource Factory</b> associated with the package.
  * <!-- end-user-doc -->
- * 
  * @see org.openhealthtools.mdht.uml.cda.core.profile.util.CDAResourceImpl
  * @generated
  */
@@ -23,7 +22,6 @@ public class CDAResourceFactoryImpl extends ResourceFactoryImpl {
 	 * Creates an instance of the resource factory.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public CDAResourceFactoryImpl() {
@@ -34,7 +32,6 @@ public class CDAResourceFactoryImpl extends ResourceFactoryImpl {
 	 * Creates an instance of the resource.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/util/CDAResourceImpl.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/util/CDAResourceImpl.java
@@ -10,7 +10,6 @@ import org.eclipse.emf.ecore.xmi.impl.XMLResourceImpl;
  * <!-- begin-user-doc -->
  * The <b>Resource </b> associated with the package.
  * <!-- end-user-doc -->
- * 
  * @see org.openhealthtools.mdht.uml.cda.core.profile.util.CDAResourceFactoryImpl
  * @generated
  */
@@ -19,9 +18,7 @@ public class CDAResourceImpl extends XMLResourceImpl {
 	 * Creates an instance of the resource.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param uri
-	 *            the URI of the new resource.
+	 * @param uri the URI of the new resource.
 	 * @generated
 	 */
 	public CDAResourceImpl(URI uri) {

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/util/CDASwitch.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/util/CDASwitch.java
@@ -45,7 +45,6 @@ import org.openhealthtools.mdht.uml.cda.core.profile.VocabSpecification;
  * until a non-null result is returned,
  * which is the result of the switch.
  * <!-- end-user-doc -->
- * 
  * @see org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage
  * @generated
  */
@@ -54,7 +53,6 @@ public class CDASwitch<T> extends Switch<T> {
 	 * The cached model package
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	protected static CDAPackage modelPackage;
@@ -63,7 +61,6 @@ public class CDASwitch<T> extends Switch<T> {
 	 * Creates an instance of the switch.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public CDASwitch() {
@@ -76,7 +73,6 @@ public class CDASwitch<T> extends Switch<T> {
 	 * Checks whether this is a switch for the given package.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @parameter ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
@@ -92,9 +88,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Act Relationship</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -109,9 +103,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Association Validation</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -126,9 +118,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Template</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -143,9 +133,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Class Validation</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -160,9 +148,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Codegen Support</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -177,9 +163,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Code System Constraint</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -194,9 +178,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Concept Domain Constraint</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -211,9 +193,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Conforms To</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -228,9 +208,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Constraint Validation</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -245,9 +223,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Entry</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -262,9 +238,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Entry Relationship</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -279,9 +253,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Null Flavor</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -296,9 +268,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Participation</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -313,9 +283,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Logical Constraint</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -330,9 +298,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Inline</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -347,9 +313,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Unimplementable</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -364,9 +328,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Property Validation</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -381,9 +343,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Code System Constraint</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -398,9 +358,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Concept Domain Constraint</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -416,9 +374,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Value Set Constraint</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -433,9 +389,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Text Value</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -450,9 +404,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Validation</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -467,9 +419,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Value Set Constraint</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -484,9 +434,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>Vocab Specification</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
@@ -501,9 +449,7 @@ public class CDASwitch<T> extends Switch<T> {
 	 * This implementation returns null;
 	 * returning a non-null result will terminate the switch, but this is the last case anyway.
 	 * <!-- end-user-doc -->
-	 * 
-	 * @param object
-	 *            the target of the switch.
+	 * @param object the target of the switch.
 	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
 	 * @generated
@@ -517,7 +463,6 @@ public class CDASwitch<T> extends Switch<T> {
 	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @return the first non-null result returned by a <code>caseXXX</code> call.
 	 * @generated
 	 */
@@ -525,250 +470,157 @@ public class CDASwitch<T> extends Switch<T> {
 	protected T doSwitch(int classifierID, EObject theEObject) {
 		switch (classifierID) {
 			case CDAPackage.ENTRY: {
-				Entry entry = (Entry) theEObject;
+				Entry entry = (Entry)theEObject;
 				T result = caseEntry(entry);
-				if (result == null) {
-					result = caseAssociationValidation(entry);
-				}
-				if (result == null) {
-					result = caseValidation(entry);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = caseAssociationValidation(entry);
+				if (result == null) result = caseValidation(entry);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.ASSOCIATION_VALIDATION: {
-				AssociationValidation associationValidation = (AssociationValidation) theEObject;
+				AssociationValidation associationValidation = (AssociationValidation)theEObject;
 				T result = caseAssociationValidation(associationValidation);
-				if (result == null) {
-					result = caseValidation(associationValidation);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = caseValidation(associationValidation);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.VALIDATION: {
-				Validation validation = (Validation) theEObject;
+				Validation validation = (Validation)theEObject;
 				T result = caseValidation(validation);
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.ENTRY_RELATIONSHIP: {
-				EntryRelationship entryRelationship = (EntryRelationship) theEObject;
+				EntryRelationship entryRelationship = (EntryRelationship)theEObject;
 				T result = caseEntryRelationship(entryRelationship);
-				if (result == null) {
-					result = caseAssociationValidation(entryRelationship);
-				}
-				if (result == null) {
-					result = caseValidation(entryRelationship);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = caseAssociationValidation(entryRelationship);
+				if (result == null) result = caseValidation(entryRelationship);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.CODEGEN_SUPPORT: {
-				CodegenSupport codegenSupport = (CodegenSupport) theEObject;
+				CodegenSupport codegenSupport = (CodegenSupport)theEObject;
 				T result = caseCodegenSupport(codegenSupport);
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.PROPERTY_VALIDATION: {
-				PropertyValidation propertyValidation = (PropertyValidation) theEObject;
+				PropertyValidation propertyValidation = (PropertyValidation)theEObject;
 				T result = casePropertyValidation(propertyValidation);
-				if (result == null) {
-					result = caseValidation(propertyValidation);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = caseValidation(propertyValidation);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.CLASS_VALIDATION: {
-				ClassValidation classValidation = (ClassValidation) theEObject;
+				ClassValidation classValidation = (ClassValidation)theEObject;
 				T result = caseClassValidation(classValidation);
-				if (result == null) {
-					result = caseValidation(classValidation);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = caseValidation(classValidation);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.VOCAB_SPECIFICATION: {
-				VocabSpecification vocabSpecification = (VocabSpecification) theEObject;
+				VocabSpecification vocabSpecification = (VocabSpecification)theEObject;
 				T result = caseVocabSpecification(vocabSpecification);
-				if (result == null) {
-					result = casePropertyValidation(vocabSpecification);
-				}
-				if (result == null) {
-					result = caseValidation(vocabSpecification);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = casePropertyValidation(vocabSpecification);
+				if (result == null) result = caseValidation(vocabSpecification);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.NULL_FLAVOR: {
-				NullFlavor nullFlavor = (NullFlavor) theEObject;
+				NullFlavor nullFlavor = (NullFlavor)theEObject;
 				T result = caseNullFlavor(nullFlavor);
-				if (result == null) {
-					result = casePropertyValidation(nullFlavor);
-				}
-				if (result == null) {
-					result = caseValidation(nullFlavor);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = casePropertyValidation(nullFlavor);
+				if (result == null) result = caseValidation(nullFlavor);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.TEXT_VALUE: {
-				TextValue textValue = (TextValue) theEObject;
+				TextValue textValue = (TextValue)theEObject;
 				T result = caseTextValue(textValue);
-				if (result == null) {
-					result = casePropertyValidation(textValue);
-				}
-				if (result == null) {
-					result = caseValidation(textValue);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = casePropertyValidation(textValue);
+				if (result == null) result = caseValidation(textValue);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.CDA_TEMPLATE: {
-				CDATemplate cdaTemplate = (CDATemplate) theEObject;
+				CDATemplate cdaTemplate = (CDATemplate)theEObject;
 				T result = caseCDATemplate(cdaTemplate);
-				if (result == null) {
-					result = caseClassValidation(cdaTemplate);
-				}
-				if (result == null) {
-					result = caseValidation(cdaTemplate);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = caseClassValidation(cdaTemplate);
+				if (result == null) result = caseValidation(cdaTemplate);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.CONSTRAINT_VALIDATION: {
-				ConstraintValidation constraintValidation = (ConstraintValidation) theEObject;
+				ConstraintValidation constraintValidation = (ConstraintValidation)theEObject;
 				T result = caseConstraintValidation(constraintValidation);
-				if (result == null) {
-					result = caseValidation(constraintValidation);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = caseValidation(constraintValidation);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.CONFORMS_TO: {
-				ConformsTo conformsTo = (ConformsTo) theEObject;
+				ConformsTo conformsTo = (ConformsTo)theEObject;
 				T result = caseConformsTo(conformsTo);
-				if (result == null) {
-					result = caseValidation(conformsTo);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = caseValidation(conformsTo);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.CONCEPT_DOMAIN_CONSTRAINT: {
-				ConceptDomainConstraint conceptDomainConstraint = (ConceptDomainConstraint) theEObject;
+				ConceptDomainConstraint conceptDomainConstraint = (ConceptDomainConstraint)theEObject;
 				T result = caseConceptDomainConstraint(conceptDomainConstraint);
-				if (result == null) {
-					result = caseTerm_ConceptDomainConstraint(conceptDomainConstraint);
-				}
-				if (result == null) {
-					result = caseValidation(conceptDomainConstraint);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = caseTerm_ConceptDomainConstraint(conceptDomainConstraint);
+				if (result == null) result = caseValidation(conceptDomainConstraint);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.CODE_SYSTEM_CONSTRAINT: {
-				CodeSystemConstraint codeSystemConstraint = (CodeSystemConstraint) theEObject;
+				CodeSystemConstraint codeSystemConstraint = (CodeSystemConstraint)theEObject;
 				T result = caseCodeSystemConstraint(codeSystemConstraint);
-				if (result == null) {
-					result = caseTerm_CodeSystemConstraint(codeSystemConstraint);
-				}
-				if (result == null) {
-					result = caseValidation(codeSystemConstraint);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = caseTerm_CodeSystemConstraint(codeSystemConstraint);
+				if (result == null) result = caseValidation(codeSystemConstraint);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.VALUE_SET_CONSTRAINT: {
-				ValueSetConstraint valueSetConstraint = (ValueSetConstraint) theEObject;
+				ValueSetConstraint valueSetConstraint = (ValueSetConstraint)theEObject;
 				T result = caseValueSetConstraint(valueSetConstraint);
-				if (result == null) {
-					result = caseTerm_ValueSetConstraint(valueSetConstraint);
-				}
-				if (result == null) {
-					result = caseValidation(valueSetConstraint);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = caseTerm_ValueSetConstraint(valueSetConstraint);
+				if (result == null) result = caseValidation(valueSetConstraint);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.ACT_RELATIONSHIP: {
-				ActRelationship actRelationship = (ActRelationship) theEObject;
+				ActRelationship actRelationship = (ActRelationship)theEObject;
 				T result = caseActRelationship(actRelationship);
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.PARTICIPATION: {
-				Participation participation = (Participation) theEObject;
+				Participation participation = (Participation)theEObject;
 				T result = caseParticipation(participation);
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.LOGICAL_CONSTRAINT: {
-				LogicalConstraint logicalConstraint = (LogicalConstraint) theEObject;
+				LogicalConstraint logicalConstraint = (LogicalConstraint)theEObject;
 				T result = caseLogicalConstraint(logicalConstraint);
-				if (result == null) {
-					result = caseConstraintValidation(logicalConstraint);
-				}
-				if (result == null) {
-					result = caseValidation(logicalConstraint);
-				}
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = caseConstraintValidation(logicalConstraint);
+				if (result == null) result = caseValidation(logicalConstraint);
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.INLINE: {
-				Inline inline = (Inline) theEObject;
+				Inline inline = (Inline)theEObject;
 				T result = caseInline(inline);
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
 			case CDAPackage.UNIMPLEMENTABLE: {
-				Unimplementable unimplementable = (Unimplementable) theEObject;
+				Unimplementable unimplementable = (Unimplementable)theEObject;
 				T result = caseUnimplementable(unimplementable);
-				if (result == null) {
-					result = defaultCase(theEObject);
-				}
+				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
-			default:
-				return defaultCase(theEObject);
+			default: return defaultCase(theEObject);
 		}
 	}
 

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/util/CDAXMLProcessor.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/profile/util/CDAXMLProcessor.java
@@ -16,7 +16,6 @@ import org.openhealthtools.mdht.uml.cda.core.profile.CDAPackage;
  * This class contains helper methods to serialize and deserialize XML documents
  * <!-- begin-user-doc -->
  * <!-- end-user-doc -->
- * 
  * @generated
  */
 public class CDAXMLProcessor extends XMLProcessor {
@@ -25,7 +24,6 @@ public class CDAXMLProcessor extends XMLProcessor {
 	 * Public constructor to instantiate the helper.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	public CDAXMLProcessor() {
@@ -37,7 +35,6 @@ public class CDAXMLProcessor extends XMLProcessor {
 	 * Register for "*" and "xml" file extensions the CDAResourceFactoryImpl factory.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * 
 	 * @generated
 	 */
 	@Override

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAConstraints.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAConstraints.java
@@ -13,6 +13,7 @@ package org.openhealthtools.mdht.uml.cda.core.util;
 
 import org.eclipse.osgi.util.NLS;
 
+@Deprecated
 public class CDAConstraints extends NLS {
 	private static final String BUNDLE_NAME = "org.openhealthtools.mdht.uml.cda.core.util.CDAConstraints"; //$NON-NLS-1$
 

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -2010,7 +2010,7 @@ public class CDAModelUtil {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see org.eclipse.core.resources.IResourceVisitor#visit(org.eclipse.core.resources.IResource)
 		 */
 		public boolean visit(IResource arg0) throws CoreException {

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -383,69 +383,81 @@ public class CDAModelUtil {
 		return (String) umlSwitch.doSwitch(element);
 	}
 
-	private static String getCDATemplateIdConstraint(boolean isTemplateVersionEmpty, boolean markup) {
-		String result = "";
-		if (isTemplateVersionEmpty) {
-			if (cardinalityAfterElement) {
-				result = markup
-						? CDAConstraints.CDATemplateIdConstraintMarkupDiffMultip
-						: CDAConstraints.CDATemplateIdConstraintDiffMultip;
-			} else {
-				result = markup
-						? CDAConstraints.CDATemplateIdConstraintMarkup
-						: CDAConstraints.CDATemplateIdConstraint;
-			}
-
-		} else {
-			if (cardinalityAfterElement) {
-				result = markup
-						? CDAConstraints.CDAVersionTemplateIdConstraintMarkupDiffMultip
-						: CDAConstraints.CDAVersionTemplateIdConstraintDiffMultip;
-			} else {
-				result = markup
-						? CDAConstraints.CDAVersionTemplateIdConstraintMarkup
-						: CDAConstraints.CDAVersionTemplateIdConstraint;
-			}
-		}
-
-		return result;
-	}
+	// private static String getCDATemplateIdConstraint(boolean isTemplateVersionEmpty, boolean markup) {
+	// String result = "";
+	// if (isTemplateVersionEmpty) {
+	// if (cardinalityAfterElement) {
+	// result = markup
+	// ? CDAConstraints.CDATemplateIdConstraintMarkupDiffMultip
+	// : CDAConstraints.CDATemplateIdConstraintDiffMultip;
+	// } else {
+	// result = markup
+	// ? CDAConstraints.CDATemplateIdConstraintMarkup
+	// : CDAConstraints.CDATemplateIdConstraint;
+	// }
+	//
+	// } else {
+	// if (cardinalityAfterElement) {
+	// result = markup
+	// ? CDAConstraints.CDAVersionTemplateIdConstraintMarkupDiffMultip
+	// : CDAConstraints.CDAVersionTemplateIdConstraintDiffMultip;
+	// } else {
+	// result = markup
+	// ? CDAConstraints.CDAVersionTemplateIdConstraintMarkup
+	// : CDAConstraints.CDAVersionTemplateIdConstraint;
+	// }
+	// }
+	//
+	// return result;
+	// }
 
 	public static String computeConformanceMessage(Class template, final boolean markup) {
 
 		String templateId = getTemplateId(template);
 		String templateVersion = getTemplateVersion(template);
-
-		String templateConstraint = getCDATemplateIdConstraint(StringUtils.isEmpty(templateVersion), markup);
-
 		String ruleIds = getConformanceRuleIds(template);
-		templateConstraint = templateConstraint.replaceAll("%templateId%", (templateId != null
-				? templateId
-				: ""));
-		templateConstraint = templateConstraint.replaceAll("\\( %ruleId% \\) ", (ruleIds != null &&
-				!ruleIds.trim().isEmpty()
-				? "( " + ruleIds + " ) "
-				: ""));
+		if (templateId == null)
+			templateId = "";
 
-		templateConstraint = templateConstraint.replaceAll("%templateVersion%", (templateVersion != null
-				? templateVersion
-				: ""));
+		// String templateConstraint = getCDATemplateIdConstraint(StringUtils.isEmpty(templateVersion), markup);
+		//
+		//
+		// templateConstraint = templateConstraint.replaceAll("%templateId%", (templateId != null
+		// ? templateId
+		// : ""));
+		// templateConstraint = templateConstraint.replaceAll("\\( %ruleId% \\) ", (ruleIds != null &&
+		// !ruleIds.trim().isEmpty()
+		// ? "( " + ruleIds + " ) "
+		// : ""));
+		//
+		// templateConstraint = templateConstraint.replaceAll("%templateVersion%", (templateVersion != null
+		// ? templateVersion
+		// : ""));
 
-		final String multiplicityRange = CDATemplateComputeBuilder.getMultiplicityRange(getMultiplicityRange(template));
+		String templateMultiplicity = CDATemplateComputeBuilder.getMultiplicityRange(getMultiplicityRange(template));
+		final String templateIdAsBusinessName = "=\"" + templateId + "\"";
+		final String templateVersionAsBusinessName = "=\"" + templateVersion + "\"";
+		final String multiplicityRange = templateMultiplicity.isEmpty()
+				? ""
+				: " [" + templateMultiplicity + "]";
 		CDATemplateComputeBuilder cdaTemplater = new CDATemplateComputeBuilder() {
 			@Override
-			public String addMultiplicity() {
+			public String addTemplateIdMultiplicity() {
 				return multiplicityElementToggle(markup, "templateId", multiplicityRange, "");
 			}
+
+			@Override
+			public String addRootMultiplicity() {
+				return multiplicityElementToggle(markup, "@root", " [1..1]", templateIdAsBusinessName);
+			}
+
+			@Override
+			public String addTemplateVersion() {
+				return multiplicityElementToggle(markup, "@extension", " [1..1]", templateVersionAsBusinessName);
+			}
 		};
-		String result = cdaTemplater.setCardinalityAfterElement(cardinalityAfterElement).setRequireMarkup(markup).setRuleIds(
-			ruleIds).setTemplateId(templateId).setTemplateVersion(templateVersion).setMultiplicity(multiplicityRange).compute().toString();
-
-		System.out.println("New multiplicity is " + result);
-
-		int asddasd = 5;// tmpwarn
-
-		return templateConstraint;
+		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(templateVersion).setMultiplicity(
+			multiplicityRange).compute().toString();
 	}
 
 	public static String computeConformanceMessage(Generalization generalization, boolean markup) {
@@ -523,7 +535,7 @@ public class CDAModelUtil {
 	private static String getBusinessName(NamedElement property) {
 		String businessName = NamedElementUtil.getBusinessName(property);
 		if (!property.getName().equals(businessName)) {
-			return (" (" + businessName + ") ");
+			return (" (" + businessName + ")");
 		}
 		return "";
 	}

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -411,7 +411,7 @@ public class CDAModelUtil {
 		return result;
 	}
 
-	public static String computeConformanceMessage(Class template, boolean markup) {
+	public static String computeConformanceMessage(Class template, final boolean markup) {
 
 		String templateId = getTemplateId(template);
 		String templateVersion = getTemplateVersion(template);
@@ -430,6 +430,15 @@ public class CDAModelUtil {
 		templateConstraint = templateConstraint.replaceAll("%templateVersion%", (templateVersion != null
 				? templateVersion
 				: ""));
+
+		CDATemplateComputeBuilder cdaTemplater = new CDATemplateComputeBuilder() {
+			@Override
+			public String addMultiplicity() {
+				return multiplicityElementToggle(markup, "templateId", "1..1", "");
+			}
+		};
+		String result = cdaTemplater.setCardinalityAfterElement(cardinalityAfterElement).setRequireMarkup(markup).setRuleIds(
+			ruleIds).setTemplateId(templateId).setTemplateVersion(templateVersion).compute().toString();
 
 		return templateConstraint;
 	}
@@ -516,8 +525,16 @@ public class CDAModelUtil {
 
 	private static StringBuffer multiplicityElementToggle(Property property, boolean markup, String elementName) {
 		StringBuffer message = new StringBuffer();
+		message.append(multiplicityElementToggle(
+			markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
+		return message;
+	}
+
+	private static String multiplicityElementToggle(boolean markup, String elementName, String multiplicityRange,
+			String businessName) {
+		StringBuffer message = new StringBuffer();
 		if (!cardinalityAfterElement) {
-			message.append(getMultiplicityRange(property));
+			message.append(multiplicityRange);
 		}
 
 		message.append(" ");
@@ -528,16 +545,15 @@ public class CDAModelUtil {
 		message.append(markup
 				? "</b>"
 				: "");
-		message.append(getBusinessName(property));
+		message.append(businessName);
 		message.append(markup
 				? "</tt>"
 				: "");
 
 		if (cardinalityAfterElement) {
-			message.append(getMultiplicityRange(property));
+			message.append(multiplicityRange);
 		}
-
-		return message;
+		return message.toString();
 	}
 
 	private static String computeAssociationConformanceMessage(Property property, boolean markup, Package xrefSource) {
@@ -2226,7 +2242,7 @@ public class CDAModelUtil {
 		return elementName;
 	}
 
-	public static String getMultiplicityRange(Property property) {
+	private static String getMultiplicityRange(Property property) {
 
 		StringBuffer message = new StringBuffer();
 		String lower = Integer.toString(property.getLower());
@@ -2237,7 +2253,7 @@ public class CDAModelUtil {
 		return message.toString();
 	}
 
-	public static String getMultiplicityText(Property property) {
+	private static String getMultiplicityText(Property property) {
 
 		StringBuffer message = new StringBuffer();
 		if (property.getLower() == 1 && property.getUpper() == 1) {

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -431,14 +431,19 @@ public class CDAModelUtil {
 				? templateVersion
 				: ""));
 
+		final String multiplicityRange = CDATemplateComputeBuilder.getMultiplicityRange(getMultiplicityRange(template));
 		CDATemplateComputeBuilder cdaTemplater = new CDATemplateComputeBuilder() {
 			@Override
 			public String addMultiplicity() {
-				return multiplicityElementToggle(markup, "templateId", "1..1", "");
+				return multiplicityElementToggle(markup, "templateId", multiplicityRange, "");
 			}
 		};
 		String result = cdaTemplater.setCardinalityAfterElement(cardinalityAfterElement).setRequireMarkup(markup).setRuleIds(
-			ruleIds).setTemplateId(templateId).setTemplateVersion(templateVersion).compute().toString();
+			ruleIds).setTemplateId(templateId).setTemplateVersion(templateVersion).setMultiplicity(multiplicityRange).compute().toString();
+
+		System.out.println("New multiplicity is " + result);
+
+		int asddasd = 5;// tmpwarn
 
 		return templateConstraint;
 	}
@@ -2005,7 +2010,7 @@ public class CDAModelUtil {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see org.eclipse.core.resources.IResourceVisitor#visit(org.eclipse.core.resources.IResource)
 		 */
 		public boolean visit(IResource arg0) throws CoreException {
@@ -2278,6 +2283,23 @@ public class CDAModelUtil {
 		}
 
 		return false;
+	}
+
+	private static String getMultiplicityRange(Class template) {
+		String templateId = null;
+		Stereotype hl7Template = CDAProfileUtil.getAppliedCDAStereotype(template, ICDAProfileConstants.CDA_TEMPLATE);
+		if (hl7Template != null) {
+			templateId = (String) template.getValue(hl7Template, ICDAProfileConstants.CDA_TEMPLATE_MULTIPLICITY);
+		} else {
+			for (Classifier parent : template.getGenerals()) {
+				templateId = getMultiplicityRange((Class) parent);
+				if (templateId != null) {
+					break;
+				}
+			}
+		}
+
+		return templateId;
 	}
 
 	public static String getTemplateId(Class template) {

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -2010,7 +2010,7 @@ public class CDAModelUtil {
 
 		/*
 		 * (non-Javadoc)
-		 *
+		 * 
 		 * @see org.eclipse.core.resources.IResourceVisitor#visit(org.eclipse.core.resources.IResource)
 		 */
 		public boolean visit(IResource arg0) throws CoreException {
@@ -2288,7 +2288,7 @@ public class CDAModelUtil {
 	private static String getMultiplicityRange(Class template) {
 		String templateId = null;
 		Stereotype hl7Template = CDAProfileUtil.getAppliedCDAStereotype(template, ICDAProfileConstants.CDA_TEMPLATE);
-		if (hl7Template != null) {
+		if (hl7Template != null && template.hasValue(hl7Template, ICDAProfileConstants.CDA_TEMPLATE_MULTIPLICITY)) {
 			templateId = (String) template.getValue(hl7Template, ICDAProfileConstants.CDA_TEMPLATE_MULTIPLICITY);
 		} else {
 			for (Classifier parent : template.getGenerals()) {

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDATemplateComputeBuilder.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDATemplateComputeBuilder.java
@@ -28,7 +28,7 @@ public abstract class CDATemplateComputeBuilder {
 	public static String getMultiplicityRange(String multiplicity) {
 		System.out.println("getmultiplicity val is " + multiplicity);
 		if (multiplicity == null) // default
-			return "[1..1]";
+			return "1..1";
 		return multiplicity;
 	}
 

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDATemplateComputeBuilder.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDATemplateComputeBuilder.java
@@ -26,6 +26,7 @@ public abstract class CDATemplateComputeBuilder {
 	private String multiplicity;
 
 	public static String getMultiplicityRange(String multiplicity) {
+		System.out.println("getmultiplicity val is " + multiplicity);
 		if (multiplicity == null) // default
 			return "[1..1]";
 		return multiplicity;

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDATemplateComputeBuilder.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDATemplateComputeBuilder.java
@@ -23,6 +23,14 @@ public abstract class CDATemplateComputeBuilder {
 
 	private String ruleIds;
 
+	private String multiplicity;
+
+	public static String getMultiplicityRange(String multiplicity) {
+		if (multiplicity == null) // default
+			return "[1..1]";
+		return multiplicity;
+	}
+
 	public CDATemplateComputeBuilder setTemplateVersion(String templateVersion) {
 		this.templateVersion = templateVersion;
 		return this;
@@ -45,6 +53,11 @@ public abstract class CDATemplateComputeBuilder {
 
 	public CDATemplateComputeBuilder setCardinalityAfterElement(Boolean cardinalityAfterElement) {
 		this.cardinalityAfterElement = cardinalityAfterElement;
+		return this;
+	}
+
+	public CDATemplateComputeBuilder setMultiplicity(String multiplicityRange) {
+		this.multiplicity = multiplicityRange;
 		return this;
 	}
 

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDATemplateComputeBuilder.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDATemplateComputeBuilder.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Sean Muir and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Sarp Kaya (NEHTA)  - initial implementation
+ *
+ *******************************************************************************/
+package org.openhealthtools.mdht.uml.cda.core.util;
+
+public abstract class CDATemplateComputeBuilder {
+
+	private String templateVersion;
+
+	private boolean markup = false;
+
+	private boolean cardinalityAfterElement = false;
+
+	private String templateId;
+
+	private String ruleIds;
+
+	public CDATemplateComputeBuilder setTemplateVersion(String templateVersion) {
+		this.templateVersion = templateVersion;
+		return this;
+	}
+
+	public CDATemplateComputeBuilder setTemplateId(String templateId) {
+		this.templateId = templateId;
+		return this;
+	}
+
+	public CDATemplateComputeBuilder setRuleIds(String ruleIds) {
+		this.ruleIds = ruleIds;
+		return this;
+	}
+
+	public CDATemplateComputeBuilder setRequireMarkup(Boolean markup) {
+		this.markup = markup;
+		return this;
+	}
+
+	public CDATemplateComputeBuilder setCardinalityAfterElement(Boolean cardinalityAfterElement) {
+		this.cardinalityAfterElement = cardinalityAfterElement;
+		return this;
+	}
+
+	public CDATemplateComputeBuilder compute() {
+		return this;
+	}
+
+	public abstract String addMultiplicity();
+
+}

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/ICDAProfileConstants.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/ICDAProfileConstants.java
@@ -4,11 +4,11 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *     David A Carlson (XMLmodeling.com) - initial API and implementation
  *     Christian W. Damus - factor out CDA dependencies from UML-to-Ecore transformation (artf3350)
- *     
+ *
  * $Id$
  *******************************************************************************/
 package org.openhealthtools.mdht.uml.cda.core.util;
@@ -136,6 +136,8 @@ public interface ICDAProfileConstants {
 	public static final String CDA_TEMPLATE_ASSIGNING_AUTHORITY_NAME = "assigningAuthorityName";
 
 	public static final String CDA_TEMPLATE_CONTEXT_DEPENDENT = "contextDependent";
+
+	public static final String CDA_TEMPLATE_MULTIPLICITY = "templateMultiplicity";
 
 	/*
 	 * ConformsTo Stereotype

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.resources/profiles/CDA.profile.uml
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.resources/profiles/CDA.profile.uml
@@ -658,6 +658,10 @@ memberEnd->forAll(type.oclIsKindOf(uml::Class) and not type.name.oclIsUndefined(
         <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2wkIMEx-EeS4r_8vH5A4uw"/>
       </ownedAttribute>
+      <ownedAttribute xmi:id="_dzsFYDADEeWB8IqcSLZ66A" name="templateMultiplicity">
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_dzsFYTADEeWB8IqcSLZ66A"/>
+      </ownedAttribute>
     </packagedElement>
     <packagedElement xmi:type="uml:Stereotype" xmi:id="_4AuRwKFKEd6NOYTVzzK9uw" name="ConstraintValidation">
       <generalization xmi:id="_9VbFkKFKEd6NOYTVzzK9uw" general="_e_WLgJmVEd6OiP9GTesZug"/>

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/properties/TemplateSection.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/properties/TemplateSection.java
@@ -46,8 +46,10 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.views.properties.tabbed.ITabbedPropertyConstants;
 import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
 import org.eclipse.uml2.uml.Class;
+import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.NamedElement;
 import org.eclipse.uml2.uml.Stereotype;
+import org.openhealthtools.mdht.uml.cda.core.profile.Validation;
 import org.openhealthtools.mdht.uml.cda.core.util.CDAProfileUtil;
 import org.openhealthtools.mdht.uml.cda.core.util.ICDAProfileConstants;
 
@@ -261,7 +263,7 @@ public class TemplateSection extends ValidationSection {
 
 		CLabel multiplicityLabel = getWidgetFactory().createCLabel(composite, "templateId Multiplicity:"); //$NON-NLS-1$
 		multiplicityCombo = getWidgetFactory().createCCombo(composite, SWT.FLAT);
-		multiplicityCombo.setItems(new String[] { "*", "0..1", "1", "1..*" });
+		multiplicityCombo.setItems(new String[] { "1", "1..*" });
 		multiplicityCombo.addSelectionListener(new SelectionListener() {
 			public void widgetDefaultSelected(SelectionEvent e) {
 				multiplicitySet();
@@ -356,11 +358,43 @@ public class TemplateSection extends ValidationSection {
 
 	private void multiplicitySet() {
 		String selectedTxt = multiplicityCombo.getText();
-		if ("*".equals(selectedTxt)) {
-			multiplicityCombo.setText("0..*");
-		} else if ("1".equals(selectedTxt)) {
+		if ("1".equals(selectedTxt)) {
 			multiplicityCombo.setText("1..1");
 		}
+		// Stereotype hl7Template = CDAProfileUtil.getAppliedCDAStereotype(template, ICDAProfileConstants.CDA_TEMPLATE);
+		Stereotype hl7Template = getValidationStereotype();
+		System.out.println("template is " + hl7Template);
+		if (hl7Template != null) {
+			String templateId = (String) modelElement.getValue(
+				hl7Template, ICDAProfileConstants.CDA_TEMPLATE_TEMPLATE_ID);
+			System.out.println("templid is " + templateId);
+		}
+		String result = getConformanceRuleIds(modelElement);
+		System.out.println("ConformId is " + result);
+		result = getConformanceRuleIds(modelElement, hl7Template);
+		System.out.println("ConformId2 is " + result);
+	}
+
+	private static String getConformanceRuleIds(Element element) {
+		Stereotype validationSupport = CDAProfileUtil.getAppliedCDAStereotype(element, ICDAProfileConstants.VALIDATION);
+		return getConformanceRuleIds(element, validationSupport);
+	}
+
+	private static String getConformanceRuleIds(Element element, Stereotype validationSupport) {
+		StringBuffer ruleIdDisplay = new StringBuffer();
+		if (validationSupport != null) {
+			Validation validation = (Validation) element.getStereotypeApplication(validationSupport);
+			for (String ruleId : validation.getRuleId()) {
+				if (ruleIdDisplay.length() > 0) {
+					ruleIdDisplay.append(", ");
+				}
+				ruleIdDisplay.append(ruleId);
+			}
+		} else {
+			System.out.println("Validationsupport is null");
+		}
+
+		return ruleIdDisplay.toString();
 	}
 
 }

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/properties/TemplateSection.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/properties/TemplateSection.java
@@ -189,7 +189,6 @@ public class TemplateSection extends ValidationSection {
 
 						if (stereotype != null) {
 							String value = multiplicityCombo.getText().trim();
-							System.out.println("Setting " + value);
 							modelElement.setValue(
 								stereotype, ICDAProfileConstants.CDA_TEMPLATE_MULTIPLICITY, value.length() > 0
 										? value
@@ -368,7 +367,6 @@ public class TemplateSection extends ValidationSection {
 		String multiplicityVal = null;
 		if (stereotype != null) {
 			multiplicityVal = (String) modelElement.getValue(stereotype, ICDAProfileConstants.CDA_TEMPLATE_MULTIPLICITY);
-			System.out.println("Multip val is " + multiplicityVal);
 		}
 
 		multiplicityCombo.setText(CDATemplateComputeBuilder.getMultiplicityRange(multiplicityVal));

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/properties/TemplateSection.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/properties/TemplateSection.java
@@ -365,14 +365,10 @@ public class TemplateSection extends ValidationSection {
 		Stereotype hl7Template = getValidationStereotype();
 		System.out.println("template is " + hl7Template);
 		if (hl7Template != null) {
-			String templateId = (String) modelElement.getValue(
-				hl7Template, ICDAProfileConstants.CDA_TEMPLATE_TEMPLATE_ID);
-			System.out.println("templid is " + templateId);
+			modelElement.setValue(
+				hl7Template, ICDAProfileConstants.CDA_TEMPLATE_MULTIPLICITY, multiplicityCombo.getText());
 		}
-		String result = getConformanceRuleIds(modelElement);
-		System.out.println("ConformId is " + result);
-		result = getConformanceRuleIds(modelElement, hl7Template);
-		System.out.println("ConformId2 is " + result);
+
 	}
 
 	private static String getConformanceRuleIds(Element element) {

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/properties/TemplateSection.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/properties/TemplateSection.java
@@ -4,12 +4,13 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *     David A Carlson (XMLmodeling.com) - initial API and implementation
  *     Kenn Hussey - adding support for restoring defaults
  *     Christian W. Damus - implement handling of live validation roll-back (artf3318)
- *     
+ *     Sarp Kaya (NEHTA)
+ *
  * $Id$
  *******************************************************************************/
 package org.openhealthtools.mdht.uml.cda.ui.properties;
@@ -26,6 +27,7 @@ import org.eclipse.emf.transaction.util.TransactionUtil;
 import org.eclipse.emf.workspace.AbstractEMFOperation;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
@@ -63,6 +65,8 @@ public class TemplateSection extends ValidationSection {
 	private Text assigningAuthorityText;
 
 	private boolean assigningAuthorityModified = false;
+
+	private CCombo multiplicityCombo;
 
 	private ModifyListener modifyListener = new ModifyListener() {
 		public void modifyText(final ModifyEvent event) {
@@ -251,6 +255,22 @@ public class TemplateSection extends ValidationSection {
 		data.top = new FormAttachment(assigningAuthorityText, 0, SWT.CENTER);
 		restoreDefaultsButton.setLayoutData(data);
 
+		// templateId Multiplicity
+
+		CLabel multiplicityLabel = getWidgetFactory().createCLabel(composite, "templateId Multiplicity:"); //$NON-NLS-1$
+		multiplicityCombo = getWidgetFactory().createCCombo(composite, SWT.FLAT);
+		multiplicityCombo.setItems(new String[] { "*", "0..1", "1", "1..*" });
+
+		data = new FormData();
+		data.right = new FormAttachment(restoreDefaultsButton, ITabbedPropertyConstants.HSPACE);
+		data.top = new FormAttachment(restoreDefaultsButton, ITabbedPropertyConstants.VSPACE);
+		multiplicityCombo.setLayoutData(data);
+
+		data = new FormData();
+		data.right = new FormAttachment(multiplicityCombo, ITabbedPropertyConstants.HSPACE);
+		data.top = new FormAttachment(multiplicityCombo, 0, SWT.CENTER);
+		multiplicityLabel.setLayoutData(data);
+
 		addValidationControls(composite, 1, 2);
 
 	}
@@ -318,6 +338,8 @@ public class TemplateSection extends ValidationSection {
 			assigningAuthorityText.setEnabled(true);
 			restoreDefaultsButton.setEnabled(stereotype != null);
 		}
+
+		multiplicityCombo.setText("m");
 
 	}
 

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/properties/TemplateSection.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/properties/TemplateSection.java
@@ -35,6 +35,8 @@ import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
@@ -260,16 +262,25 @@ public class TemplateSection extends ValidationSection {
 		CLabel multiplicityLabel = getWidgetFactory().createCLabel(composite, "templateId Multiplicity:"); //$NON-NLS-1$
 		multiplicityCombo = getWidgetFactory().createCCombo(composite, SWT.FLAT);
 		multiplicityCombo.setItems(new String[] { "*", "0..1", "1", "1..*" });
+		multiplicityCombo.addSelectionListener(new SelectionListener() {
+			public void widgetDefaultSelected(SelectionEvent e) {
+				multiplicitySet();
+			}
+
+			public void widgetSelected(SelectionEvent e) {
+				multiplicitySet();
+			}
+		});
 
 		data = new FormData();
-		data.right = new FormAttachment(restoreDefaultsButton, ITabbedPropertyConstants.HSPACE);
-		data.top = new FormAttachment(restoreDefaultsButton, ITabbedPropertyConstants.VSPACE);
-		multiplicityCombo.setLayoutData(data);
-
-		data = new FormData();
-		data.right = new FormAttachment(multiplicityCombo, ITabbedPropertyConstants.HSPACE);
-		data.top = new FormAttachment(multiplicityCombo, 0, SWT.CENTER);
+		data.left = new FormAttachment(assigningAuthorityText, 0, SWT.CENTER);
+		data.top = new FormAttachment(assigningAuthorityText, ITabbedPropertyConstants.VSPACE);
 		multiplicityLabel.setLayoutData(data);
+
+		data = new FormData();
+		data.left = new FormAttachment(multiplicityLabel, ITabbedPropertyConstants.HSPACE);
+		data.top = new FormAttachment(multiplicityLabel, 0, SWT.CENTER);
+		multiplicityCombo.setLayoutData(data);
 
 		addValidationControls(composite, 1, 2);
 
@@ -341,6 +352,15 @@ public class TemplateSection extends ValidationSection {
 
 		multiplicityCombo.setText("m");
 
+	}
+
+	private void multiplicitySet() {
+		String selectedTxt = multiplicityCombo.getText();
+		if ("*".equals(selectedTxt)) {
+			multiplicityCombo.setText("0..*");
+		} else if ("1".equals(selectedTxt)) {
+			multiplicityCombo.setText("1..1");
+		}
 	}
 
 }


### PR DESCRIPTION
The attribute templateId by default is [0..*] in CDA. However without further constraint it is always published as "SHALL contain exactly one [1..1] templateId() such that......". So this fix adds a new drop down for multiplicityId. Previous CDA template conformance message was hardcoded, this PR also deprecates the hardcoded values and calculates messages.
