### PR TITLE
Associations printed in the right order fix

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/TransformClassContent.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/TransformClassContent.java
@@ -4,10 +4,10 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *     David A Carlson (XMLmodeling.com) - initial API and implementation
- *     
+ *
  * $Id$
  *******************************************************************************/
 package org.openhealthtools.mdht.uml.cda.dita;
@@ -61,6 +61,7 @@ import org.openhealthtools.mdht.uml.cda.core.util.InstanceGenerator;
 import org.openhealthtools.mdht.uml.cda.core.util.RIMModelUtil;
 import org.openhealthtools.mdht.uml.cda.dita.internal.Logger;
 import org.openhealthtools.mdht.uml.common.util.NamedElementComparator;
+import org.openhealthtools.mdht.uml.common.util.PropertyComparator;
 import org.openhealthtools.mdht.uml.common.util.UMLUtil;
 
 public class TransformClassContent extends TransformAbstract {
@@ -405,6 +406,7 @@ public class TransformClassContent extends TransformAbstract {
 			appendPropertyRules(writer, property, constraintMap, subConstraintMap, unprocessedConstraints);
 			writer.println("</li>");
 		}
+		Collections.sort(allProperties, new PropertyComparator());
 		// XML elements
 		for (Property property : allProperties) {
 			hasRules = true;
@@ -745,7 +747,7 @@ public class TransformClassContent extends TransformAbstract {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see org.eclipse.compare.rangedifferencer.IRangeComparator#getRangeCount()
 		 */
 		public int getRangeCount() {
@@ -754,7 +756,7 @@ public class TransformClassContent extends TransformAbstract {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see org.eclipse.compare.rangedifferencer.IRangeComparator#rangesEqual(int, org.eclipse.compare.rangedifferencer.IRangeComparator, int)
 		 */
 		public boolean rangesEqual(int thisIndex, IRangeComparator other, int otherIndex) {
@@ -765,7 +767,7 @@ public class TransformClassContent extends TransformAbstract {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see org.eclipse.compare.rangedifferencer.IRangeComparator#skipRangeComparison(int, int,
 		 * org.eclipse.compare.rangedifferencer.IRangeComparator)
 		 */

--- a/core/plugins/org.openhealthtools.mdht.uml.common/src/org/openhealthtools/mdht/uml/common/util/PropertyComparator.java
+++ b/core/plugins/org.openhealthtools.mdht.uml.common/src/org/openhealthtools/mdht/uml/common/util/PropertyComparator.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2015
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Sarp Kaya (NEHTA) - initial API and implementation
+ *
+ * $Id$
+ *******************************************************************************/
+package org.openhealthtools.mdht.uml.common.util;
+
+import java.util.Comparator;
+
+import org.eclipse.uml2.uml.Association;
+import org.eclipse.uml2.uml.Property;
+
+/**
+ * Compare two NamedElement objects, for sorting collections by name.
+ *
+ * @version $Id: $
+ */
+public class PropertyComparator implements Comparator<Property> {
+
+	/*
+	 * (non-Javadoc)
+	 * Compares the associations
+	 * 
+	 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
+	 */
+	public int compare(Property o1, Property o2) {
+		Association assoc1 = o1.getAssociation();
+		Association assoc2 = o2.getAssociation();
+		if (assoc1 == null && assoc2 != null) {
+			return -1;
+		} else if (assoc1 != null && assoc2 == null) {
+			return 1;
+		}
+		return 0;
+	}
+
+}


### PR DESCRIPTION
While attributes are printed in the same order as they are in the model, sometimes an association will be printed in the middle of the attributes instead of its right place as dictated by the model. This PR fixes that issue.

This issue will be raised for a discussion in the next MDHT meeting.
