### PR TITLE
Informative text not to be ordered

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/TransformClassContent.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/TransformClassContent.java
@@ -510,13 +510,11 @@ public class TransformClassContent extends TransformAbstract {
 		}
 
 		if (property.getOwnedComments().size() > 0) {
-			writer.append("<ul>");
 			for (Comment comment : property.getOwnedComments()) {
-				writer.append("<li><p><lines><i>");
+				writer.append("<p><lines><i>");
 				writer.append(CDAModelUtil.fixNonXMLCharacters(comment.getBody()));
-				writer.append("</i></lines></p></li>");
+				writer.append("</i></lines></p>");
 			}
-			writer.append("</ul>");
 		}
 	}
 

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/TransformClassContent.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/TransformClassContent.java
@@ -510,13 +510,13 @@ public class TransformClassContent extends TransformAbstract {
 		}
 
 		if (property.getOwnedComments().size() > 0) {
-			writer.append("<ol>");
+			writer.append("<ul>");
 			for (Comment comment : property.getOwnedComments()) {
 				writer.append("<li><p><lines><i>");
 				writer.append(CDAModelUtil.fixNonXMLCharacters(comment.getBody()));
 				writer.append("</i></lines></p></li>");
 			}
-			writer.append("</ol>");
+			writer.append("</ul>");
 		}
 	}
 


### PR DESCRIPTION
Informative text was wrapped around <ol><li> which is now removed due to confusion.
