### PR TITLE
Choosing severity to none

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/properties/ValidationSection.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ui/src/org/openhealthtools/mdht/uml/cda/ui/properties/ValidationSection.java
@@ -148,7 +148,8 @@ public abstract class ValidationSection extends ResettableModelerPropertySection
 						if (severityKind != null) {
 							if (severityCombo.getSelectionIndex() == 0) {
 								// remove stereotype property
-								modelElement.setValue(stereotype, ICDAProfileConstants.VALIDATION_SEVERITY, null);
+								// modelElement.setValue(stereotype, ICDAProfileConstants.VALIDATION_SEVERITY, null);
+								modelElement.unapplyStereotype(stereotype);
 							} else {
 								EnumerationLiteral literal = severityKind.getOwnedLiterals().get(
 									severityCombo.getSelectionIndex() - 1);


### PR DESCRIPTION
Setting stereotype to null doesn't work as they are linked to messages (INFO, WARNING and ERROR) where null is equal to ERROR. So instead I unapplied the stereotype.
