### PR TITLE
Enable DITA checkbox on the Constraints Section

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/internal/TextEditor.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/internal/TextEditor.java
@@ -15,6 +15,9 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.uml2.uml.Class;
 import org.eclipse.uml2.uml.Constraint;
+import org.eclipse.uml2.uml.Stereotype;
+import org.openhealthtools.mdht.uml.cda.core.util.CDAProfileUtil;
+import org.openhealthtools.mdht.uml.cda.core.util.ICDAProfileConstants;
 import org.openhealthtools.mdht.uml.cda.dita.DitaTransformerOptions;
 import org.openhealthtools.mdht.uml.cda.dita.TransformClassContent;
 import org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor;
@@ -53,15 +56,14 @@ public class TextEditor implements ConstraintEditor {
 	}
 
 	private boolean isDitaEnabled() {
-		return true;
-		// Boolean ditaEnabled = false;
-		// try {
-		// Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
-		// constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
-		// ditaEnabled = (Boolean) constraint.getValue(stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED);
-		// } catch (IllegalArgumentException ex) { /* Swallow this */
-		// }
-		// return ditaEnabled;
+		Boolean ditaEnabled = false;
+		try {
+			Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
+				constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+			ditaEnabled = (Boolean) constraint.getValue(stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED);
+		} catch (IllegalArgumentException ex) { /* Swallow this */
+		}
+		return ditaEnabled;
 	}
 
 	private void handleChange() {

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/sections/ConstraintSection.java
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/sections/ConstraintSection.java
@@ -70,8 +70,11 @@ import org.eclipse.uml2.uml.Classifier;
 import org.eclipse.uml2.uml.Constraint;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.OpaqueExpression;
+import org.eclipse.uml2.uml.Stereotype;
 import org.eclipse.uml2.uml.UMLPackage;
 import org.eclipse.uml2.uml.ValueSpecification;
+import org.openhealthtools.mdht.uml.cda.core.util.CDAProfileUtil;
+import org.openhealthtools.mdht.uml.cda.core.util.ICDAProfileConstants;
 import org.openhealthtools.mdht.uml.ui.properties.internal.UmlUiEditor;
 import org.openhealthtools.mdht.uml.ui.properties.sections.WrapperAwareModelerPropertySection;
 import org.openhealthtools.mdht.uml.validation.ocl.EcoreProfileEnvironment;
@@ -219,6 +222,25 @@ public class ConstraintSection extends WrapperAwareModelerPropertySection {
 								// create new specification entry
 								oESpec.getLanguages().add(language);
 								oESpec.getBodies().add(body);
+							}
+						}
+						if (ditaModified) {
+							ditaModified = false;
+							Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
+								constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+
+							if (stereotype == null) {
+								stereotype = CDAProfileUtil.applyCDAStereotype(
+									constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+							}
+							constraint.setValue(
+								stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED,
+								ditaEnableButton.getSelection());
+
+							// Also don't show errors if they are visible
+							if (!ditaEnableButton.getSelection()) {
+								errorText.setVisible(false);
+								closeErrorTextButton.setVisible(false);
 							}
 						}
 					} else {
@@ -550,6 +572,22 @@ public class ConstraintSection extends WrapperAwareModelerPropertySection {
 		} else {
 			languageCombo.setEnabled(true);
 			bodyText.setEnabled(true);
+		}
+		if ("Analysis".equals(languageCombo.getText())) {
+			Boolean selection = false;
+			try {
+				Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
+					constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+				selection = (Boolean) constraint.getValue(stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED);
+			} catch (IllegalArgumentException e) { /* Swallow this */
+			}
+			selection = selection == null
+					? false
+					: selection;
+			ditaEnableButton.setSelection(selection);
+			ditaEnableButton.setVisible(true);
+		} else {
+			ditaEnableButton.setVisible(false);
 		}
 
 	}


### PR DESCRIPTION
This revert:
https://github.com/mdht/mdht/commit/6af50c7053b11e3ef4aaaa2c810941bfa1ed714d

removed the dependency to Enable DITA. Later on Sean commited this:
https://github.com/mdht/mdht/commit/bd7fbbab0536a3a993c442e9be588589a86a318a

and that caused the button to disappear.

This PR fixes that issue
