### PR TITLE
Enable DITA checkbox on the Constraints Section

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/internal/TextEditor.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/internal/TextEditor.java
@@ -66,6 +66,18 @@ public class TextEditor implements ConstraintEditor {
 		return ditaEnabled;
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setDitaEnabled(boolean)
+	 */
+	@Override
+	public void setDitaEnabled(boolean isEnabled) {
+		Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
+			constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+		constraint.setValue(stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED, isEnabled);
+	}
+
 	private void handleChange() {
 		if (checkDita && isDitaEnabled()) {
 			runHandleChange();
@@ -109,7 +121,7 @@ public class TextEditor implements ConstraintEditor {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setConstraint(org.eclipse.uml2.uml.Constraint)
 	 */
 	public void setConstraint(Constraint constraint) {
@@ -142,7 +154,7 @@ public class TextEditor implements ConstraintEditor {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setErrorText(org.eclipse.swt.widgets.Text)
 	 */
 	@Override
@@ -153,7 +165,7 @@ public class TextEditor implements ConstraintEditor {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setCloseErrorText(org.eclipse.swt.widgets.Button)
 	 */
 	@Override

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/internal/TextEditor.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/internal/TextEditor.java
@@ -15,6 +15,9 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.uml2.uml.Class;
 import org.eclipse.uml2.uml.Constraint;
+import org.eclipse.uml2.uml.Stereotype;
+import org.openhealthtools.mdht.uml.cda.core.util.CDAProfileUtil;
+import org.openhealthtools.mdht.uml.cda.core.util.ICDAProfileConstants;
 import org.openhealthtools.mdht.uml.cda.dita.DitaTransformerOptions;
 import org.openhealthtools.mdht.uml.cda.dita.TransformClassContent;
 import org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor;
@@ -53,15 +56,14 @@ public class TextEditor implements ConstraintEditor {
 	}
 
 	private boolean isDitaEnabled() {
-		return true;
-		// Boolean ditaEnabled = false;
-		// try {
-		// Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
-		// constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
-		// ditaEnabled = (Boolean) constraint.getValue(stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED);
-		// } catch (IllegalArgumentException ex) { /* Swallow this */
-		// }
-		// return ditaEnabled;
+		Boolean ditaEnabled = false;
+		try {
+			Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
+				constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+			ditaEnabled = (Boolean) constraint.getValue(stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED);
+		} catch (IllegalArgumentException ex) { /* Swallow this */
+		}
+		return ditaEnabled;
 	}
 
 	private void handleChange() {

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/internal/TextEditor.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/internal/TextEditor.java
@@ -55,7 +55,11 @@ public class TextEditor implements ConstraintEditor {
 		});
 	}
 
-	private boolean isDitaEnabled() {
+	/**
+	 * @return the value stored in the Dita Enabled constraint
+	 *         true iff the constraint has a Boolean of true, false otherwise
+	 */
+	public boolean isDitaEnabled() {
 		Boolean ditaEnabled = false;
 		try {
 			Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
@@ -69,7 +73,7 @@ public class TextEditor implements ConstraintEditor {
 	/*
 	 * (non-Javadoc)
 	 * 
-	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setDitaEnabled(boolean)
+	 * * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setDitaEnabled(boolean)
 	 */
 	@Override
 	public void setDitaEnabled(boolean isEnabled) {
@@ -154,7 +158,7 @@ public class TextEditor implements ConstraintEditor {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setErrorText(org.eclipse.swt.widgets.Text)
 	 */
 	@Override
@@ -165,7 +169,7 @@ public class TextEditor implements ConstraintEditor {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setCloseErrorText(org.eclipse.swt.widgets.Button)
 	 */
 	@Override

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/internal/TextEditor.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/internal/TextEditor.java
@@ -59,6 +59,7 @@ public class TextEditor implements ConstraintEditor {
 	 * @return the value stored in the Dita Enabled constraint
 	 *         true iff the constraint has a Boolean of true, false otherwise
 	 */
+	@Override
 	public boolean isDitaEnabled() {
 		Boolean ditaEnabled = false;
 		try {
@@ -79,7 +80,13 @@ public class TextEditor implements ConstraintEditor {
 	public void setDitaEnabled(boolean isEnabled) {
 		Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
 			constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+
+		if (stereotype == null) {
+			stereotype = CDAProfileUtil.applyCDAStereotype(constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+		}
+
 		constraint.setValue(stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED, isEnabled);
+
 	}
 
 	private void handleChange() {
@@ -128,6 +135,7 @@ public class TextEditor implements ConstraintEditor {
 	 * 
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setConstraint(org.eclipse.uml2.uml.Constraint)
 	 */
+	@Override
 	public void setConstraint(Constraint constraint) {
 		boolean firstRun = this.constraint == null && constraint != null;
 		this.constraint = constraint;

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/LanguageEditor.java
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/LanguageEditor.java
@@ -45,7 +45,7 @@ public class LanguageEditor extends UmlUiEditor {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setConstraint(org.eclipse.uml2.uml.Constraint)
 	 */
 	public void setConstraint(Constraint constraint) {
@@ -54,7 +54,7 @@ public class LanguageEditor extends UmlUiEditor {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setErrorText(org.eclipse.swt.widgets.Text)
 	 */
 	@Override
@@ -65,13 +65,23 @@ public class LanguageEditor extends UmlUiEditor {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setCloseErrorText(org.eclipse.swt.widgets.Button)
 	 */
 	@Override
 	public void setCloseErrorText(Button closeErrorTextButton) {
 		// TODO Auto-generated method stub
 
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setDitaEnabled(boolean)
+	 */
+	@Override
+	public void setDitaEnabled(boolean isEnabled) {
+		// TODO Auto-generated method stub
 	}
 
 }

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/LanguageEditor.java
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/LanguageEditor.java
@@ -45,7 +45,7 @@ public class LanguageEditor extends UmlUiEditor {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setConstraint(org.eclipse.uml2.uml.Constraint)
 	 */
 	public void setConstraint(Constraint constraint) {
@@ -54,7 +54,7 @@ public class LanguageEditor extends UmlUiEditor {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setErrorText(org.eclipse.swt.widgets.Text)
 	 */
 	@Override
@@ -65,7 +65,7 @@ public class LanguageEditor extends UmlUiEditor {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setCloseErrorText(org.eclipse.swt.widgets.Button)
 	 */
 	@Override
@@ -76,12 +76,23 @@ public class LanguageEditor extends UmlUiEditor {
 
 	/*
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#setDitaEnabled(boolean)
 	 */
 	@Override
 	public void setDitaEnabled(boolean isEnabled) {
 		// TODO Auto-generated method stub
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.openhealthtools.mdht.uml.ui.properties.internal.sections.ConstraintEditor#isDitaEnabled()
+	 */
+	@Override
+	public boolean isDitaEnabled() {
+		// TODO Auto-generated method stub
+		return false;
 	}
 
 }

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/sections/ConstraintEditor.java
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/sections/ConstraintEditor.java
@@ -27,4 +27,6 @@ public interface ConstraintEditor {
 	void setErrorText(Text errorText);
 
 	void setCloseErrorText(Button closeErrorTextButton);
+
+	void setDitaEnabled(boolean isEnabled);
 }

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/sections/ConstraintEditor.java
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/sections/ConstraintEditor.java
@@ -29,4 +29,9 @@ public interface ConstraintEditor {
 	void setCloseErrorText(Button closeErrorTextButton);
 
 	void setDitaEnabled(boolean isEnabled);
+
+	/*
+	 * retrun the value of DITA enabled plugin
+	 */
+	boolean isDitaEnabled();
 }

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/sections/ConstraintSection.java
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/sections/ConstraintSection.java
@@ -226,16 +226,18 @@ public class ConstraintSection extends WrapperAwareModelerPropertySection {
 						}
 						if (ditaModified) {
 							ditaModified = false;
-							Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
-								constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+							contributors.get(language).setDitaEnabled(ditaEnableButton.getSelection());
 
-							if (stereotype == null) {
-								stereotype = CDAProfileUtil.applyCDAStereotype(
-									constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
-							}
-							constraint.setValue(
-								stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED,
-								ditaEnableButton.getSelection());
+							// Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
+							// constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+							//
+							// if (stereotype == null) {
+							// stereotype = CDAProfileUtil.applyCDAStereotype(
+							// constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+							// }
+							// constraint.setValue(
+							// stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED,
+							// ditaEnableButton.getSelection());
 
 							// Also don't show errors if they are visible
 							if (!ditaEnableButton.getSelection()) {
@@ -441,9 +443,9 @@ public class ConstraintSection extends WrapperAwareModelerPropertySection {
 
 	/*
 	 * Override super implementation to allow for objects that are not IAdaptable.
-	 *
+	 * 
 	 * (non-Javadoc)
-	 *
+	 * 
 	 * @see org.eclipse.gmf.runtime.diagram.ui.properties.sections.AbstractModelerPropertySection#addToEObjectList(java.lang.Object)
 	 */
 	@SuppressWarnings("unchecked")

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/sections/ConstraintSection.java
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/sections/ConstraintSection.java
@@ -70,11 +70,8 @@ import org.eclipse.uml2.uml.Classifier;
 import org.eclipse.uml2.uml.Constraint;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.OpaqueExpression;
-import org.eclipse.uml2.uml.Stereotype;
 import org.eclipse.uml2.uml.UMLPackage;
 import org.eclipse.uml2.uml.ValueSpecification;
-import org.openhealthtools.mdht.uml.cda.core.util.CDAProfileUtil;
-import org.openhealthtools.mdht.uml.cda.core.util.ICDAProfileConstants;
 import org.openhealthtools.mdht.uml.ui.properties.internal.UmlUiEditor;
 import org.openhealthtools.mdht.uml.ui.properties.sections.WrapperAwareModelerPropertySection;
 import org.openhealthtools.mdht.uml.validation.ocl.EcoreProfileEnvironment;
@@ -228,17 +225,6 @@ public class ConstraintSection extends WrapperAwareModelerPropertySection {
 							ditaModified = false;
 							contributors.get(language).setDitaEnabled(ditaEnableButton.getSelection());
 
-							// Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
-							// constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
-							//
-							// if (stereotype == null) {
-							// stereotype = CDAProfileUtil.applyCDAStereotype(
-							// constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
-							// }
-							// constraint.setValue(
-							// stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED,
-							// ditaEnableButton.getSelection());
-
 							// Also don't show errors if they are visible
 							if (!ditaEnableButton.getSelection()) {
 								errorText.setVisible(false);
@@ -354,6 +340,7 @@ public class ConstraintSection extends WrapperAwareModelerPropertySection {
 		ditaEnableButton.setLayoutData(data);
 		ditaEnableButton.setEnabled(true);
 		ditaEnableButton.setVisible(false);
+
 		ditaEnableButton.addSelectionListener(new SelectionListener() {
 			public void widgetDefaultSelected(SelectionEvent e) {
 				ditaModified = true;
@@ -443,9 +430,9 @@ public class ConstraintSection extends WrapperAwareModelerPropertySection {
 
 	/*
 	 * Override super implementation to allow for objects that are not IAdaptable.
-	 * 
+	 *
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.gmf.runtime.diagram.ui.properties.sections.AbstractModelerPropertySection#addToEObjectList(java.lang.Object)
 	 */
 	@SuppressWarnings("unchecked")
@@ -576,17 +563,7 @@ public class ConstraintSection extends WrapperAwareModelerPropertySection {
 			bodyText.setEnabled(true);
 		}
 		if ("Analysis".equals(languageCombo.getText())) {
-			Boolean selection = false;
-			try {
-				Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
-					constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
-				selection = (Boolean) constraint.getValue(stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED);
-			} catch (IllegalArgumentException e) { /* Swallow this */
-			}
-			selection = selection == null
-					? false
-					: selection;
-			ditaEnableButton.setSelection(selection);
+			ditaEnableButton.setSelection(contributors.get(language).isDitaEnabled());
 			ditaEnableButton.setVisible(true);
 		} else {
 			ditaEnableButton.setVisible(false);

--- a/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/sections/ConstraintSection.java
+++ b/core/plugins/org.openhealthtools.mdht.uml.ui.properties/src/org/openhealthtools/mdht/uml/ui/properties/internal/sections/ConstraintSection.java
@@ -70,8 +70,11 @@ import org.eclipse.uml2.uml.Classifier;
 import org.eclipse.uml2.uml.Constraint;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.OpaqueExpression;
+import org.eclipse.uml2.uml.Stereotype;
 import org.eclipse.uml2.uml.UMLPackage;
 import org.eclipse.uml2.uml.ValueSpecification;
+import org.openhealthtools.mdht.uml.cda.core.util.CDAProfileUtil;
+import org.openhealthtools.mdht.uml.cda.core.util.ICDAProfileConstants;
 import org.openhealthtools.mdht.uml.ui.properties.internal.UmlUiEditor;
 import org.openhealthtools.mdht.uml.ui.properties.sections.WrapperAwareModelerPropertySection;
 import org.openhealthtools.mdht.uml.validation.ocl.EcoreProfileEnvironment;
@@ -219,6 +222,25 @@ public class ConstraintSection extends WrapperAwareModelerPropertySection {
 								// create new specification entry
 								oESpec.getLanguages().add(language);
 								oESpec.getBodies().add(body);
+							}
+						}
+						if (ditaModified) {
+							ditaModified = false;
+							Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
+								constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+
+							if (stereotype == null) {
+								stereotype = CDAProfileUtil.applyCDAStereotype(
+									constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+							}
+							constraint.setValue(
+								stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED,
+								ditaEnableButton.getSelection());
+
+							// Also don't show errors if they are visible
+							if (!ditaEnableButton.getSelection()) {
+								errorText.setVisible(false);
+								closeErrorTextButton.setVisible(false);
 							}
 						}
 					} else {
@@ -550,6 +572,22 @@ public class ConstraintSection extends WrapperAwareModelerPropertySection {
 		} else {
 			languageCombo.setEnabled(true);
 			bodyText.setEnabled(true);
+		}
+		if ("Analysis".equals(languageCombo.getText())) {
+			Boolean selection = false;
+			try {
+				Stereotype stereotype = CDAProfileUtil.getAppliedCDAStereotype(
+					constraint, ICDAProfileConstants.CONSTRAINT_VALIDATION);
+				selection = (Boolean) constraint.getValue(stereotype, ICDAProfileConstants.CONSTRAINT_DITA_ENABLED);
+			} catch (IllegalArgumentException e) { /* Swallow this */
+			}
+			selection = selection == null
+					? false
+					: selection;
+			ditaEnableButton.setSelection(selection);
+			ditaEnableButton.setVisible(true);
+		} else {
+			ditaEnableButton.setVisible(false);
 		}
 
 	}


### PR DESCRIPTION
This revert:
6af50c7

removed the dependency to Enable DITA. Later
bd7fbba
caused the button to disappear.

This PR fixes that issue
