### PR TITLE
redefinition names are added to xsi type

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -150,7 +150,7 @@ public class CDAModelUtil {
 
 	/**
 	 * Returns the nearest inherited property with the same name, or null if not found.
-	 * 
+	 *
 	 * @deprecated Use the {@link UMLUtil#getInheritedProperty(Property)} API, instead.
 	 */
 	@Deprecated
@@ -176,7 +176,7 @@ public class CDAModelUtil {
 	/**
 	 * isCDAModel - use get top package to support nested uml packages within CDA model
 	 * primarily used for extensions
-	 * 
+	 *
 	 */
 	public static boolean isCDAModel(Element element) {
 		if (element != null) {
@@ -318,14 +318,14 @@ public class CDAModelUtil {
 	/**
 	 * Obtains the user-specified validation message recorded in the given stereotype, or else
 	 * {@linkplain #computeConformanceMessage(Element, boolean) computes} a suitable conformance message if none.
-	 * 
+	 *
 	 * @param element
 	 *            an element on which a validation constraint stereotype is defined
 	 * @param validationStereotypeName
 	 *            the stereotype name (may be the abstract {@linkplain ICDAProfileConstants#VALIDATION Validation} stereotype)
-	 * 
+	 *
 	 * @return the most appropriate validation/conformance message
-	 * 
+	 *
 	 * @see #computeConformanceMessage(Element, boolean)
 	 */
 	public static String getValidationMessage(Element element, String validationStereotypeName) {
@@ -950,7 +950,12 @@ public class CDAModelUtil {
 		if (property.getType() != null &&
 				((redefinedProperty == null || (!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
 			message.append(" with " + "@xsi:type=\"");
-			message.append(property.getType().getName());
+			if (redefinedProperty != null && redefinedProperty.getType() != null &&
+					redefinedProperty.getType().getName() != null && !redefinedProperty.getType().getName().isEmpty()) {
+				message.append(redefinedProperty.getType().getName());
+			} else {
+				message.append(property.getType().getName());
+			}
 			message.append("\"");
 
 		}
@@ -1726,9 +1731,9 @@ public class CDAModelUtil {
 	/**
 	 * FindResourcesByNameVisitor searches the resource for resources of a particular name
 	 * You would think there was a method for this already but i could not find it
-	 * 
+	 *
 	 * @author seanmuir
-	 * 
+	 *
 	 */
 	public static class FindResourcesByNameVisitor implements IResourceVisitor {
 
@@ -1753,7 +1758,7 @@ public class CDAModelUtil {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see org.eclipse.core.resources.IResourceVisitor#visit(org.eclipse.core.resources.IResource)
 		 */
 		public boolean visit(IResource arg0) throws CoreException {
@@ -1799,9 +1804,9 @@ public class CDAModelUtil {
 
 	/**
 	 * computeXref returns the XREF for DITA publication
-	 * 
+	 *
 	 * TODO Refactor and move out of model util
-	 * 
+	 *
 	 * @param source
 	 * @param target
 	 * @return
@@ -1891,7 +1896,7 @@ public class CDAModelUtil {
 
 	/**
 	 * getExtensionNamespace returns the name space from a extension package in the CDA model
-	 * 
+	 *
 	 * @param type
 	 * @return
 	 */
@@ -1927,13 +1932,13 @@ public class CDAModelUtil {
 
 	/**
 	 * getCDAElementName - Returns the CDA Element name as a string
-	 * 
+	 *
 	 * @TODO Refactor to use org.openhealthtools.mdht.uml.transform.ecore.TransformAbstract.getInitialProperty(Property)
-	 * 
+	 *
 	 *       Currently walk the redefines to see if we can match the CDA property using the name and type
 	 *       If none found - for backwards compatibility we look for a property in the base class with a matching type which is potential error prone
 	 *       If none still - leverage the getassociation
-	 * 
+	 *
 	 * @param property
 	 * @return
 	 */


### PR DESCRIPTION
Previously xsi:type was only adding the property type's name ignoring if there was a redefinition or not. This PR fixes the issue by also considering redefinitions.
