### PR TITLE
Don't check Xml attribute for default values

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -909,7 +909,7 @@ public class CDAModelUtil {
 
 		message.append(getBusinessName(property));
 
-		if (isXMLAttribute(property) && property.getDefault() != null) {
+		if (property.getDefault() != null) {
 			message.append("=\"").append(property.getDefault()).append("\" ");
 		}
 		message.append(markup
@@ -1790,7 +1790,7 @@ public class CDAModelUtil {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see org.eclipse.core.resources.IResourceVisitor#visit(org.eclipse.core.resources.IResource)
 		 */
 		public boolean visit(IResource arg0) throws CoreException {


### PR DESCRIPTION
## Fix a failure to publish some fixed value constraints.

Where a Default Value: field has been filled with a valid value and the Read Only select box has been ticked make sure that:

```
the value in the Default Value: field is a fixed value
MDHT treats this as a fixed value constraint
fixed value constraints (as all constraints should be) are represented in the documentation output, i.e. DITA, PDF
fixed value constraints (as all constraints should be) are represented in the validation output, i.e. OCL, Java code
```

NOTE: It is also expected that if a fixed value is not allowed to be set the Default Value field will not be available.
