### PR TITLE
Added SHOULD NOT support for publication.

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -160,7 +160,7 @@ public class CDAModelUtil {
 
 	/**
 	 * Returns the nearest inherited property with the same name, or null if not found.
-	 * 
+	 *
 	 * @deprecated Use the {@link UMLUtil#getInheritedProperty(Property)} API, instead.
 	 */
 	@Deprecated
@@ -186,7 +186,7 @@ public class CDAModelUtil {
 	/**
 	 * isCDAModel - use get top package to support nested uml packages within CDA model
 	 * primarily used for extensions
-	 * 
+	 *
 	 */
 	public static boolean isCDAModel(Element element) {
 		if (element != null) {
@@ -257,11 +257,10 @@ public class CDAModelUtil {
 			String cdaName = cdaClass == null
 					? null
 					: cdaClass.getName();
-			if (cdaClass != null &&
-					("Act".equals(cdaName) || "Encounter".equals(cdaName) || "Observation".equals(cdaName) ||
-							"ObservationMedia".equals(cdaName) || "Organizer".equals(cdaName) ||
-							"Procedure".equals(cdaName) || "RegionOfInterest".equals(cdaName) ||
-							"SubstanceAdministration".equals(cdaName) || "Supply".equals(cdaName))) {
+			if (cdaClass != null && ("Act".equals(cdaName) || "Encounter".equals(cdaName) ||
+					"Observation".equals(cdaName) || "ObservationMedia".equals(cdaName) ||
+					"Organizer".equals(cdaName) || "Procedure".equals(cdaName) || "RegionOfInterest".equals(cdaName) ||
+					"SubstanceAdministration".equals(cdaName) || "Supply".equals(cdaName))) {
 				return true;
 			}
 		}
@@ -328,14 +327,14 @@ public class CDAModelUtil {
 	/**
 	 * Obtains the user-specified validation message recorded in the given stereotype, or else
 	 * {@linkplain #computeConformanceMessage(Element, boolean) computes} a suitable conformance message if none.
-	 * 
+	 *
 	 * @param element
 	 *            an element on which a validation constraint stereotype is defined
 	 * @param validationStereotypeName
 	 *            the stereotype name (may be the abstract {@linkplain ICDAProfileConstants#VALIDATION Validation} stereotype)
-	 * 
+	 *
 	 * @return the most appropriate validation/conformance message
-	 * 
+	 *
 	 * @see #computeConformanceMessage(Element, boolean)
 	 */
 	public static String getValidationMessage(Element element, String validationStereotypeName) {
@@ -421,8 +420,8 @@ public class CDAModelUtil {
 				return multiplicityElementToggle(markup, "@extension", " [1..1]", templateVersionAsBusinessName);
 			}
 		};
-		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(templateVersion).setMultiplicity(
-			multiplicityRange).compute().toString();
+		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(
+			templateVersion).setMultiplicity(multiplicityRange).compute().toString();
 	}
 
 	public static String computeConformanceMessage(Generalization generalization, boolean markup) {
@@ -507,8 +506,8 @@ public class CDAModelUtil {
 
 	private static StringBuffer multiplicityElementToggle(Property property, boolean markup, String elementName) {
 		StringBuffer message = new StringBuffer();
-		message.append(multiplicityElementToggle(
-			markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
+		message.append(
+			multiplicityElementToggle(markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
 		return message;
 	}
 
@@ -595,9 +594,12 @@ public class CDAModelUtil {
 
 				appendConformanceRules(sb, endType, (property.getUpper() == 1
 						? "This "
-						: "Such ") + (property.getUpper() == 1
-						? elementName
-						: NameUtilities.pluralize(elementName)) + " ", markup);
+						: "Such ") +
+						(property.getUpper() == 1
+								? elementName
+								: NameUtilities.pluralize(elementName)) +
+						" ",
+					markup);
 				message.append(" " + sb + " ");
 
 			} else {
@@ -682,9 +684,12 @@ public class CDAModelUtil {
 
 				appendConformanceRules(sb, inlinedClass, (property.getUpper() == 1
 						? "This "
-						: "Such ") + (property.getUpper() == 1
-						? elementName
-						: NameUtilities.pluralize(elementName)) + " ", markup);
+						: "Such ") +
+						(property.getUpper() == 1
+								? elementName
+								: NameUtilities.pluralize(elementName)) +
+						" ",
+					markup);
 				message.append(" " + sb);
 
 			}
@@ -722,9 +727,10 @@ public class CDAModelUtil {
 			message.append("Contains ");
 			message.append(markup
 					? "<tt><b>"
-					: "").append("@typeCode=\"").append(markup
-					? "</b>"
-					: "");
+					: "").append("@typeCode=\"").append(
+						markup
+								? "</b>"
+								: "");
 			message.append(typeCode).append("\" ");
 			message.append(markup
 					? "</tt>"
@@ -809,7 +815,8 @@ public class CDAModelUtil {
 			if (eReferenceStereoetype != null) {
 				String nameSpace = (String) cdaBaseProperty.getValue(eReferenceStereoetype, CDAModelUtil.XMLNAMESPACE);
 				if (!StringUtils.isEmpty(nameSpace)) {
-					Package topPackage = org.openhealthtools.mdht.uml.common.util.UMLUtil.getTopPackage(cdaBaseProperty.getNearestPackage());
+					Package topPackage = org.openhealthtools.mdht.uml.common.util.UMLUtil.getTopPackage(
+						cdaBaseProperty.getNearestPackage());
 					Stereotype ePackageStereoetype = topPackage.getApplicableStereotype(CDAModelUtil.EPACKAGE);
 					if (ePackageStereoetype != null) {
 						if (nameSpace.equals(topPackage.getValue(ePackageStereoetype, CDAModelUtil.NSURI))) {
@@ -890,7 +897,8 @@ public class CDAModelUtil {
 		TransformProvider newContributor = null;
 		Property cdaProperty = null;
 		try {
-			newContributor = (TransformProvider) extensions[0].getConfigurationElements()[0].createExecutableExtension("transform-class");
+			newContributor = (TransformProvider) extensions[0].getConfigurationElements()[0].createExecutableExtension(
+				"transform-class");
 			cdaProperty = newContributor.GetTransform(property);
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -962,11 +970,13 @@ public class CDAModelUtil {
 					textValue, ICDAProfileConstants.VALIDATION_SEVERITY);
 				message.append(" and ").append(markup
 						? "<b>"
-						: "").append(level != null
-						? getValidationKeyword(level.getLiteral())
-						: keyword).append(markup
-						? "</b>"
-						: "").append(" equal \"").append(value).append("\"");
+						: "").append(
+							level != null
+									? getValidationKeyword(level.getLiteral())
+									: keyword).append(
+										markup
+												? "</b>"
+												: "").append(" equal \"").append(value).append("\"");
 			}
 		}
 
@@ -978,8 +988,8 @@ public class CDAModelUtil {
 				? null
 				: redefinedProperties.get(0);
 
-		if (property.getType() != null &&
-				((redefinedProperty == null || (!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
+		if (property.getType() != null && ((redefinedProperty == null ||
+				(!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
 			message.append(" with " + "@xsi:type=\"");
 			if (redefinedProperty != null && redefinedProperty.getType() != null &&
 					redefinedProperty.getType().getName() != null && !redefinedProperty.getType().getName().isEmpty()) {
@@ -1037,10 +1047,10 @@ public class CDAModelUtil {
 
 				if (isPublishSeperately((Class) property.getType())) {
 
-					String xref = (property.getType() instanceof Classifier && UMLUtil.isSameProject(
-						property, property.getType()))
-							? computeXref(xrefSource, (Classifier) property.getType())
-							: null;
+					String xref = (property.getType() instanceof Classifier &&
+							UMLUtil.isSameProject(property, property.getType()))
+									? computeXref(xrefSource, (Classifier) property.getType())
+									: null;
 					boolean showXref = markup && (xref != null);
 
 					if (showXref) {
@@ -1187,17 +1197,15 @@ public class CDAModelUtil {
 
 		// XML attributes
 		for (Property property : propertyList.getAttributes()) {
-			hasRules = hasRules |
-					appendPropertyList(
-						umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
-						subConstraintMap);
+			hasRules = hasRules | appendPropertyList(
+				umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
+				subConstraintMap);
 		}
 		// XML elements
 		for (Property property : propertyList.getAssociationEnds()) {
-			hasRules = hasRules |
-					appendPropertyList(
-						umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
-						subConstraintMap);
+			hasRules = hasRules | appendPropertyList(
+				umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
+				subConstraintMap);
 		}
 
 		for (Constraint constraint : unprocessedConstraints) {
@@ -1317,7 +1325,8 @@ public class CDAModelUtil {
 	}
 
 	private static void appendSubConstraintRules(StringBuffer ruleConstraints, Constraint constraint,
-			Map<Constraint, List<Constraint>> subConstraintMap, List<Constraint> unprocessedConstraints, boolean markup) {
+			Map<Constraint, List<Constraint>> subConstraintMap, List<Constraint> unprocessedConstraints,
+			boolean markup) {
 
 		String[] ol;
 		String[] li;
@@ -1755,19 +1764,22 @@ public class CDAModelUtil {
 			String propertyKeyword = getValidationKeyword(constraint.getConstrainedElements().get(0));
 
 			if (propertyKeyword != null) {
-				message.append(computeConformanceMessage(constraint.getConstrainedElements().get(0), markup).replace(
-					propertyKeyword, ""));
+				message.append(
+					computeConformanceMessage(constraint.getConstrainedElements().get(0), markup).replace(
+						propertyKeyword, ""));
 			} else {
 				message.append(computeConformanceMessage(constraint.getConstrainedElements().get(0), markup));
 			}
 
 			message.append(" then it ").append(markup
 					? "<lines>"
-					: "").append(markup
-					? "<b>"
-					: "").append(keyword).append(markup
-					? "</b> "
-					: " ");
+					: "").append(
+						markup
+								? "<b>"
+								: "").append(keyword).append(
+									markup
+											? "</b> "
+											: " ");
 
 			message.append(computeConformanceMessage(constraint.getConstrainedElements().get(1), markup));
 			message.append(markup
@@ -1812,9 +1824,9 @@ public class CDAModelUtil {
 	/**
 	 * FindResourcesByNameVisitor searches the resource for resources of a particular name
 	 * You would think there was a method for this already but i could not find it
-	 * 
+	 *
 	 * @author seanmuir
-	 * 
+	 *
 	 */
 	public static class FindResourcesByNameVisitor implements IResourceVisitor {
 
@@ -1839,7 +1851,7 @@ public class CDAModelUtil {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see org.eclipse.core.resources.IResourceVisitor#visit(org.eclipse.core.resources.IResource)
 		 */
 		public boolean visit(IResource arg0) throws CoreException {
@@ -1885,9 +1897,9 @@ public class CDAModelUtil {
 
 	/**
 	 * computeXref returns the XREF for DITA publication
-	 * 
+	 *
 	 * TODO Refactor and move out of model util
-	 * 
+	 *
 	 * @param source
 	 * @param target
 	 * @return
@@ -1977,7 +1989,7 @@ public class CDAModelUtil {
 
 	/**
 	 * getExtensionNamespace returns the name space from a extension package in the CDA model
-	 * 
+	 *
 	 * @param type
 	 * @return
 	 */
@@ -2013,13 +2025,13 @@ public class CDAModelUtil {
 
 	/**
 	 * getCDAElementName - Returns the CDA Element name as a string
-	 * 
+	 *
 	 * @TODO Refactor to use org.openhealthtools.mdht.uml.transform.ecore.TransformAbstract.getInitialProperty(Property)
-	 * 
+	 *
 	 *       Currently walk the redefines to see if we can match the CDA property using the name and type
 	 *       If none found - for backwards compatibility we look for a property in the base class with a matching type which is potential error prone
 	 *       If none still - leverage the getassociation
-	 * 
+	 *
 	 * @param property
 	 * @return
 	 */
@@ -2113,7 +2125,8 @@ public class CDAModelUtil {
 			elementName = "entry";
 		} else if (CDAModelUtil.isOrganizer(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
 			elementName = "component";
-		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
+		} else
+			if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
 			elementName = "entryRelationship";
 		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && cdaTargetClass != null &&
 				"ParticipantRole".equals(cdaTargetClass.getName())) {
@@ -2138,15 +2151,15 @@ public class CDAModelUtil {
 	}
 
 	/*
-	 * 
+	 *
 	 * · 0..1 zero or one
-	 * 
+	 *
 	 * · 1..1 exactly one
-	 * 
+	 *
 	 * · 1..* at least one
-	 * 
+	 *
 	 * · 0..* zero or more
-	 * 
+	 *
 	 * · 1..n at least one and not more than n
 	 */
 
@@ -2175,8 +2188,9 @@ public class CDAModelUtil {
 			if (property.getUpper() == -1) {
 				message.append("at least one");
 			} else {
-				message.append("at least " + convertNumberToWords(property.getLower()) + " and not more than " +
-						convertNumberToWords(property.getUpper()));
+				message.append(
+					"at least " + convertNumberToWords(property.getLower()) + " and not more than " +
+							convertNumberToWords(property.getUpper()));
 			}
 		} else {
 			// Lower is greater then 1
@@ -2201,7 +2215,7 @@ public class CDAModelUtil {
 
 	/**
 	 * Converts an integer number into words (american english).
-	 * 
+	 *
 	 * @author Christian d'Heureuse, Inventec Informatik AG, Switzerland, www.source-code.biz
 	 **/
 	private static String convertNumberToWords(int n) {

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -16,6 +16,7 @@
  *     								 - added message support for errata 384 as per artf3818 No Information Section Fix
  *     								 - support templateId extension attribute value in generalization and association messages
  *     Sarp Kaya (NEHTA)
+ *     Vadim Peretokin (NEHTA) - added handling of SHOULD + 0..0 multiplicity to produce publication text "SHALL NOT"
  * $Id$
  *******************************************************************************/
 package org.openhealthtools.mdht.uml.cda.core.util;
@@ -159,7 +160,7 @@ public class CDAModelUtil {
 
 	/**
 	 * Returns the nearest inherited property with the same name, or null if not found.
-	 *
+	 * 
 	 * @deprecated Use the {@link UMLUtil#getInheritedProperty(Property)} API, instead.
 	 */
 	@Deprecated
@@ -185,7 +186,7 @@ public class CDAModelUtil {
 	/**
 	 * isCDAModel - use get top package to support nested uml packages within CDA model
 	 * primarily used for extensions
-	 *
+	 * 
 	 */
 	public static boolean isCDAModel(Element element) {
 		if (element != null) {
@@ -256,10 +257,11 @@ public class CDAModelUtil {
 			String cdaName = cdaClass == null
 					? null
 					: cdaClass.getName();
-			if (cdaClass != null && ("Act".equals(cdaName) || "Encounter".equals(cdaName) ||
-					"Observation".equals(cdaName) || "ObservationMedia".equals(cdaName) ||
-					"Organizer".equals(cdaName) || "Procedure".equals(cdaName) || "RegionOfInterest".equals(cdaName) ||
-					"SubstanceAdministration".equals(cdaName) || "Supply".equals(cdaName))) {
+			if (cdaClass != null &&
+					("Act".equals(cdaName) || "Encounter".equals(cdaName) || "Observation".equals(cdaName) ||
+							"ObservationMedia".equals(cdaName) || "Organizer".equals(cdaName) ||
+							"Procedure".equals(cdaName) || "RegionOfInterest".equals(cdaName) ||
+							"SubstanceAdministration".equals(cdaName) || "Supply".equals(cdaName))) {
 				return true;
 			}
 		}
@@ -326,14 +328,14 @@ public class CDAModelUtil {
 	/**
 	 * Obtains the user-specified validation message recorded in the given stereotype, or else
 	 * {@linkplain #computeConformanceMessage(Element, boolean) computes} a suitable conformance message if none.
-	 *
+	 * 
 	 * @param element
 	 *            an element on which a validation constraint stereotype is defined
 	 * @param validationStereotypeName
 	 *            the stereotype name (may be the abstract {@linkplain ICDAProfileConstants#VALIDATION Validation} stereotype)
-	 *
+	 * 
 	 * @return the most appropriate validation/conformance message
-	 *
+	 * 
 	 * @see #computeConformanceMessage(Element, boolean)
 	 */
 	public static String getValidationMessage(Element element, String validationStereotypeName) {
@@ -419,8 +421,8 @@ public class CDAModelUtil {
 				return multiplicityElementToggle(markup, "@extension", " [1..1]", templateVersionAsBusinessName);
 			}
 		};
-		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(
-			templateVersion).setMultiplicity(multiplicityRange).compute().toString();
+		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(templateVersion).setMultiplicity(
+			multiplicityRange).compute().toString();
 	}
 
 	public static String computeConformanceMessage(Generalization generalization, boolean markup) {
@@ -505,8 +507,8 @@ public class CDAModelUtil {
 
 	private static StringBuffer multiplicityElementToggle(Property property, boolean markup, String elementName) {
 		StringBuffer message = new StringBuffer();
-		message.append(
-			multiplicityElementToggle(markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
+		message.append(multiplicityElementToggle(
+			markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
 		return message;
 	}
 
@@ -593,12 +595,9 @@ public class CDAModelUtil {
 
 				appendConformanceRules(sb, endType, (property.getUpper() == 1
 						? "This "
-						: "Such ") +
-						(property.getUpper() == 1
-								? elementName
-								: NameUtilities.pluralize(elementName)) +
-						" ",
-					markup);
+						: "Such ") + (property.getUpper() == 1
+						? elementName
+						: NameUtilities.pluralize(elementName)) + " ", markup);
 				message.append(" " + sb + " ");
 
 			} else {
@@ -683,12 +682,9 @@ public class CDAModelUtil {
 
 				appendConformanceRules(sb, inlinedClass, (property.getUpper() == 1
 						? "This "
-						: "Such ") +
-						(property.getUpper() == 1
-								? elementName
-								: NameUtilities.pluralize(elementName)) +
-						" ",
-					markup);
+						: "Such ") + (property.getUpper() == 1
+						? elementName
+						: NameUtilities.pluralize(elementName)) + " ", markup);
 				message.append(" " + sb);
 
 			}
@@ -726,10 +722,9 @@ public class CDAModelUtil {
 			message.append("Contains ");
 			message.append(markup
 					? "<tt><b>"
-					: "").append("@typeCode=\"").append(
-						markup
-								? "</b>"
-								: "");
+					: "").append("@typeCode=\"").append(markup
+					? "</b>"
+					: "");
 			message.append(typeCode).append("\" ");
 			message.append(markup
 					? "</tt>"
@@ -814,8 +809,7 @@ public class CDAModelUtil {
 			if (eReferenceStereoetype != null) {
 				String nameSpace = (String) cdaBaseProperty.getValue(eReferenceStereoetype, CDAModelUtil.XMLNAMESPACE);
 				if (!StringUtils.isEmpty(nameSpace)) {
-					Package topPackage = org.openhealthtools.mdht.uml.common.util.UMLUtil.getTopPackage(
-						cdaBaseProperty.getNearestPackage());
+					Package topPackage = org.openhealthtools.mdht.uml.common.util.UMLUtil.getTopPackage(cdaBaseProperty.getNearestPackage());
 					Stereotype ePackageStereoetype = topPackage.getApplicableStereotype(CDAModelUtil.EPACKAGE);
 					if (ePackageStereoetype != null) {
 						if (nameSpace.equals(topPackage.getValue(ePackageStereoetype, CDAModelUtil.NSURI))) {
@@ -896,8 +890,7 @@ public class CDAModelUtil {
 		TransformProvider newContributor = null;
 		Property cdaProperty = null;
 		try {
-			newContributor = (TransformProvider) extensions[0].getConfigurationElements()[0].createExecutableExtension(
-				"transform-class");
+			newContributor = (TransformProvider) extensions[0].getConfigurationElements()[0].createExecutableExtension("transform-class");
 			cdaProperty = newContributor.GetTransform(property);
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -969,13 +962,11 @@ public class CDAModelUtil {
 					textValue, ICDAProfileConstants.VALIDATION_SEVERITY);
 				message.append(" and ").append(markup
 						? "<b>"
-						: "").append(
-							level != null
-									? getValidationKeyword(level.getLiteral())
-									: keyword).append(
-										markup
-												? "</b>"
-												: "").append(" equal \"").append(value).append("\"");
+						: "").append(level != null
+						? getValidationKeyword(level.getLiteral())
+						: keyword).append(markup
+						? "</b>"
+						: "").append(" equal \"").append(value).append("\"");
 			}
 		}
 
@@ -987,8 +978,8 @@ public class CDAModelUtil {
 				? null
 				: redefinedProperties.get(0);
 
-		if (property.getType() != null && ((redefinedProperty == null ||
-				(!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
+		if (property.getType() != null &&
+				((redefinedProperty == null || (!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
 			message.append(" with " + "@xsi:type=\"");
 			if (redefinedProperty != null && redefinedProperty.getType() != null &&
 					redefinedProperty.getType().getName() != null && !redefinedProperty.getType().getName().isEmpty()) {
@@ -1046,10 +1037,10 @@ public class CDAModelUtil {
 
 				if (isPublishSeperately((Class) property.getType())) {
 
-					String xref = (property.getType() instanceof Classifier &&
-							UMLUtil.isSameProject(property, property.getType()))
-									? computeXref(xrefSource, (Classifier) property.getType())
-									: null;
+					String xref = (property.getType() instanceof Classifier && UMLUtil.isSameProject(
+						property, property.getType()))
+							? computeXref(xrefSource, (Classifier) property.getType())
+							: null;
 					boolean showXref = markup && (xref != null);
 
 					if (showXref) {
@@ -1196,15 +1187,17 @@ public class CDAModelUtil {
 
 		// XML attributes
 		for (Property property : propertyList.getAttributes()) {
-			hasRules = hasRules | appendPropertyList(
-				umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
-				subConstraintMap);
+			hasRules = hasRules |
+					appendPropertyList(
+						umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
+						subConstraintMap);
 		}
 		// XML elements
 		for (Property property : propertyList.getAssociationEnds()) {
-			hasRules = hasRules | appendPropertyList(
-				umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
-				subConstraintMap);
+			hasRules = hasRules |
+					appendPropertyList(
+						umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
+						subConstraintMap);
 		}
 
 		for (Constraint constraint : unprocessedConstraints) {
@@ -1324,8 +1317,7 @@ public class CDAModelUtil {
 	}
 
 	private static void appendSubConstraintRules(StringBuffer ruleConstraints, Constraint constraint,
-			Map<Constraint, List<Constraint>> subConstraintMap, List<Constraint> unprocessedConstraints,
-			boolean markup) {
+			Map<Constraint, List<Constraint>> subConstraintMap, List<Constraint> unprocessedConstraints, boolean markup) {
 
 		String[] ol;
 		String[] li;
@@ -1763,22 +1755,19 @@ public class CDAModelUtil {
 			String propertyKeyword = getValidationKeyword(constraint.getConstrainedElements().get(0));
 
 			if (propertyKeyword != null) {
-				message.append(
-					computeConformanceMessage(constraint.getConstrainedElements().get(0), markup).replace(
-						propertyKeyword, ""));
+				message.append(computeConformanceMessage(constraint.getConstrainedElements().get(0), markup).replace(
+					propertyKeyword, ""));
 			} else {
 				message.append(computeConformanceMessage(constraint.getConstrainedElements().get(0), markup));
 			}
 
 			message.append(" then it ").append(markup
 					? "<lines>"
-					: "").append(
-						markup
-								? "<b>"
-								: "").append(keyword).append(
-									markup
-											? "</b> "
-											: " ");
+					: "").append(markup
+					? "<b>"
+					: "").append(keyword).append(markup
+					? "</b> "
+					: " ");
 
 			message.append(computeConformanceMessage(constraint.getConstrainedElements().get(1), markup));
 			message.append(markup
@@ -1823,9 +1812,9 @@ public class CDAModelUtil {
 	/**
 	 * FindResourcesByNameVisitor searches the resource for resources of a particular name
 	 * You would think there was a method for this already but i could not find it
-	 *
+	 * 
 	 * @author seanmuir
-	 *
+	 * 
 	 */
 	public static class FindResourcesByNameVisitor implements IResourceVisitor {
 
@@ -1850,7 +1839,7 @@ public class CDAModelUtil {
 
 		/*
 		 * (non-Javadoc)
-		 *
+		 * 
 		 * @see org.eclipse.core.resources.IResourceVisitor#visit(org.eclipse.core.resources.IResource)
 		 */
 		public boolean visit(IResource arg0) throws CoreException {
@@ -1896,9 +1885,9 @@ public class CDAModelUtil {
 
 	/**
 	 * computeXref returns the XREF for DITA publication
-	 *
+	 * 
 	 * TODO Refactor and move out of model util
-	 *
+	 * 
 	 * @param source
 	 * @param target
 	 * @return
@@ -1988,7 +1977,7 @@ public class CDAModelUtil {
 
 	/**
 	 * getExtensionNamespace returns the name space from a extension package in the CDA model
-	 *
+	 * 
 	 * @param type
 	 * @return
 	 */
@@ -2024,13 +2013,13 @@ public class CDAModelUtil {
 
 	/**
 	 * getCDAElementName - Returns the CDA Element name as a string
-	 *
+	 * 
 	 * @TODO Refactor to use org.openhealthtools.mdht.uml.transform.ecore.TransformAbstract.getInitialProperty(Property)
-	 *
+	 * 
 	 *       Currently walk the redefines to see if we can match the CDA property using the name and type
 	 *       If none found - for backwards compatibility we look for a property in the base class with a matching type which is potential error prone
 	 *       If none still - leverage the getassociation
-	 *
+	 * 
 	 * @param property
 	 * @return
 	 */
@@ -2124,8 +2113,7 @@ public class CDAModelUtil {
 			elementName = "entry";
 		} else if (CDAModelUtil.isOrganizer(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
 			elementName = "component";
-		} else
-			if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
+		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
 			elementName = "entryRelationship";
 		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && cdaTargetClass != null &&
 				"ParticipantRole".equals(cdaTargetClass.getName())) {
@@ -2150,15 +2138,15 @@ public class CDAModelUtil {
 	}
 
 	/*
-	 *
+	 * 
 	 * · 0..1 zero or one
-	 *
+	 * 
 	 * · 1..1 exactly one
-	 *
+	 * 
 	 * · 1..* at least one
-	 *
+	 * 
 	 * · 0..* zero or more
-	 *
+	 * 
 	 * · 1..n at least one and not more than n
 	 */
 
@@ -2187,9 +2175,8 @@ public class CDAModelUtil {
 			if (property.getUpper() == -1) {
 				message.append("at least one");
 			} else {
-				message.append(
-					"at least " + convertNumberToWords(property.getLower()) + " and not more than " +
-							convertNumberToWords(property.getUpper()));
+				message.append("at least " + convertNumberToWords(property.getLower()) + " and not more than " +
+						convertNumberToWords(property.getUpper()));
 			}
 		} else {
 			// Lower is greater then 1
@@ -2214,7 +2201,7 @@ public class CDAModelUtil {
 
 	/**
 	 * Converts an integer number into words (american english).
-	 *
+	 * 
 	 * @author Christian d'Heureuse, Inventec Informatik AG, Switzerland, www.source-code.biz
 	 **/
 	private static String convertNumberToWords(int n) {
@@ -2595,7 +2582,8 @@ public class CDAModelUtil {
 	}
 
 	private static String addShallNot(String keyword, Property property) {
-		if (property.getLower() == 0 && property.getUpper() == 0 && "SHALL".equals(keyword)) {
+		if (property.getLower() == 0 && property.getUpper() == 0 &&
+				("SHALL".equals(keyword) || "SHOULD".equals(keyword))) {
 			keyword += " NOT";
 		}
 		return keyword;


### PR DESCRIPTION
Using a multiplicity of 0..0 with a SHOULD severity will now produce the corresponding "SHOULD NOT contain myElement" text.

OCL generation doesn't need to be updated as the previous commit 89902d5e66c073216f2a6af100b1f8bb25dea4d4 applies to this usecase already.

I also ran the MDHT cleanup profile on this, which is why everything is changed - this _should_ be the last time CDAModelUtil gets formatting changes.
