### PR TITLE
Formatting: remove vertical lines in dita tables

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.ant/tasks/org/openhealthtools/mdht/uml/cda/ant/taskdefs/TransformToDita.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.ant/tasks/org/openhealthtools/mdht/uml/cda/ant/taskdefs/TransformToDita.java
@@ -53,6 +53,8 @@ public class TransformToDita extends CDAModelingSubTask {
 
 	private Boolean appendConformanceRules = null;
 
+	private Boolean noVerticalLinesInTables = null;
+
 	private Boolean includeVocabularyConstraints = null;
 
 	private int exampleDepth;
@@ -149,6 +151,11 @@ public class TransformToDita extends CDAModelingSubTask {
 		if (includeVocabularyConstraints == null && project.getProperty("includeVocabularyConstraints") != null) {
 			includeVocabularyConstraints = Boolean.valueOf(project.getProperty("includeVocabularyConstraints"));
 		}
+
+		if (noVerticalLinesInTables == null && project.getProperty("noVerticalLinesInTables") != null) {
+			noVerticalLinesInTables = Boolean.valueOf(project.getProperty("noVerticalLinesInTables"));
+		}
+
 		if (includeTableView == null && project.getProperty("includeTableView") != null) {
 			includeTableView = Boolean.valueOf(project.getProperty("includeTableView"));
 		}
@@ -194,6 +201,10 @@ public class TransformToDita extends CDAModelingSubTask {
 
 	public void setAppendConformanceRules(boolean appendConformanceRules) {
 		this.appendConformanceRules = new Boolean(appendConformanceRules);
+	}
+
+	public void setNoVerticalLinesInTables(boolean noVerticalLinesInTables) {
+		this.noVerticalLinesInTables = new Boolean(noVerticalLinesInTables);
 	}
 
 	// ANT task child elements
@@ -245,6 +256,10 @@ public class TransformToDita extends CDAModelingSubTask {
 
 		if (appendConformanceRules != null) {
 			options.setAppendConformanceRules(appendConformanceRules);
+		}
+
+		if (noVerticalLinesInTables != null) {
+			options.setNoVerticalLinesInTables(noVerticalLinesInTables);
 		}
 
 		if (includeVocabularyConstraints != null) {

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/DitaTransformerOptions.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/DitaTransformerOptions.java
@@ -58,6 +58,8 @@ public class DitaTransformerOptions {
 
 	private boolean appendConformanceRules = false;
 
+	private boolean noVerticalLinesInTables;
+
 	private boolean includeVocabularyConstraints = false;
 
 	private int exampleDepth;
@@ -135,6 +137,20 @@ public class DitaTransformerOptions {
 		return appendConformanceRules;
 	}
 
+	/**
+	 * The value of the noVerticalLinesInTables attribute in the dita-transform ant task xml
+	 * If set, use <br>
+	 *
+	 * {@code <table frame="topbot" rowsep="1">} <br>
+	 * instead of <br>
+	 * {@code <table frame="all" rowsep="1" colsep="1"> }
+	 *
+	 * @return appendConformanceRules
+	 */
+	public boolean isNoVerticalLinesInTables() {
+		return noVerticalLinesInTables;
+	}
+
 	public boolean isIncludeTableView() {
 		return includeTableView;
 	}
@@ -157,6 +173,15 @@ public class DitaTransformerOptions {
 	 */
 	public void setAppendConformanceRules(boolean appendConformanceRules) {
 		this.appendConformanceRules = appendConformanceRules;
+	}
+
+	/**
+	 * @param noVerticalLinesInTables
+	 *            should the Dita transformer disable vertical lines in tables
+	 */
+	public void setNoVerticalLinesInTables(Boolean noVerticalLinesInTables) {
+		this.noVerticalLinesInTables = noVerticalLinesInTables;
+
 	}
 
 	public boolean isIncludeVocabularyConstraints() {

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/TransformValueSet.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.dita/src/org/openhealthtools/mdht/uml/cda/dita/TransformValueSet.java
@@ -4,14 +4,14 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *     David A Carlson (XMLmodeling.com) - initial API and implementation
  *     Les Westberg - Fixed a problem related to generating the DITA for value sets
- *                    that were not contained in the vocab project and that are in 
+ *                    that were not contained in the vocab project and that are in
  *                    models which are not based on CDA
- *                   
- *     
+ *
+ *
  * $Id$
  *******************************************************************************/
 package org.openhealthtools.mdht.uml.cda.dita;
@@ -74,8 +74,11 @@ public class TransformValueSet extends TransformAbstract {
 
 		if (!umlEnumeration.getOwnedLiterals().isEmpty()) {
 
+			// print the <table> tag
+			writer.println(getTableType());
+
 			if (transformerOptions.isIncludeUsageNotes()) {
-				writer.println("<table frame=\"all\" rowsep=\"1\" colsep=\"1\"><tgroup cols=\"4\">");
+				writer.println("<tgroup cols=\"4\">");
 				writer.println("<colspec colname=\"col1\" colwidth=\"1*\"/>");
 				writer.println("<colspec colname=\"col2\" colwidth=\"1*\"/>");
 				writer.println("<colspec colname=\"col3\" colwidth=\"1*\"/>");
@@ -84,7 +87,7 @@ public class TransformValueSet extends TransformAbstract {
 				writer.println("<entry>Code</entry><entry>Code System</entry><entry>Print Name</entry><entry>Usage Note</entry>");
 				writer.println("</row></thead><tbody>");
 			} else {
-				writer.println("<table frame=\"all\" rowsep=\"1\" colsep=\"1\"><tgroup cols=\"3\">");
+				writer.println("<tgroup cols=\"3\">");
 				writer.println("<colspec colname=\"col1\" colwidth=\"1*\"/>");
 				writer.println("<colspec colname=\"col2\" colwidth=\"1*\"/>");
 				writer.println("<colspec colname=\"col3\" colwidth=\"2*\"/>");
@@ -130,8 +133,23 @@ public class TransformValueSet extends TransformAbstract {
 		}
 	}
 
-	private static void appendDefinition(PrintWriter writer, Enumeration umlEnumeration) {
-		writer.println("<table frame=\"all\" rowsep=\"1\" colsep=\"1\"><tgroup cols=\"2\">");
+	/**
+	 * Using transformerOptions determine the correct table type to use for
+	 * output
+	 *
+	 * @return either {@code <table frame=\"topbot\" rowsep=\"1\"> } if isNoVerticalLinesInTables is set
+	 *         or {@code <table frame=\"all\" rowsep=\"1\" colsep=\"1\"> }
+	 */
+	private String getTableType() {
+		return transformerOptions.isNoVerticalLinesInTables()
+				? "<table frame=\"topbot\" rowsep=\"1\">"
+				: "<table frame=\"all\" rowsep=\"1\" colsep=\"1\">";
+
+	}
+
+	private void appendDefinition(PrintWriter writer, Enumeration umlEnumeration) {
+		writer.println(getTableType());
+		writer.println("<tgroup cols=\"2\">");
 		writer.println("<colspec colname=\"col1\" colwidth=\"1*\"/>");
 		writer.println("<colspec colname=\"col2\" colwidth=\"4*\"/>");
 		writer.println("<tbody>");


### PR DESCRIPTION
when an attribute (noVerticalLinesInTables) is set to true in the transformToDita tag, the dita transform will use a different table definition to not show virtical lines in the pdf.
