### PR TITLE
Use CDA names instead of UML names in all cases

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -24,7 +24,6 @@ package org.openhealthtools.mdht.uml.cda.core.util;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +46,24 @@ import org.eclipse.emf.common.util.Enumerator;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.uml2.common.util.UML2Util;
+import org.eclipse.uml2.uml.Association;
+import org.eclipse.uml2.uml.Class;
+import org.eclipse.uml2.uml.Classifier;
+import org.eclipse.uml2.uml.Comment;
+import org.eclipse.uml2.uml.Constraint;
+import org.eclipse.uml2.uml.Element;
+import org.eclipse.uml2.uml.Enumeration;
+import org.eclipse.uml2.uml.EnumerationLiteral;
+import org.eclipse.uml2.uml.Generalization;
+import org.eclipse.uml2.uml.NamedElement;
+import org.eclipse.uml2.uml.OpaqueExpression;
+import org.eclipse.uml2.uml.Package;
+import org.eclipse.uml2.uml.Property;
+import org.eclipse.uml2.uml.Stereotype;
+import org.eclipse.uml2.uml.Type;
+import org.eclipse.uml2.uml.ValueSpecification;
+import org.eclipse.uml2.uml.util.UMLSwitch;
 import org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship;
 import org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind;
 import org.openhealthtools.mdht.uml.cda.core.profile.Inline;
@@ -64,8 +81,6 @@ import org.openhealthtools.mdht.uml.term.core.profile.ValueSetConstraint;
 import org.openhealthtools.mdht.uml.term.core.profile.ValueSetVersion;
 import org.openhealthtools.mdht.uml.term.core.util.ITermProfileConstants;
 import org.openhealthtools.mdht.uml.term.core.util.TermProfileUtil;
-
-import com.google.common.collect.Constraint;
 
 public class CDAModelUtil {
 

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -24,7 +24,6 @@ package org.openhealthtools.mdht.uml.cda.core.util;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +46,24 @@ import org.eclipse.emf.common.util.Enumerator;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.uml2.common.util.UML2Util;
+import org.eclipse.uml2.uml.Association;
+import org.eclipse.uml2.uml.Class;
+import org.eclipse.uml2.uml.Classifier;
+import org.eclipse.uml2.uml.Comment;
+import org.eclipse.uml2.uml.Constraint;
+import org.eclipse.uml2.uml.Element;
+import org.eclipse.uml2.uml.Enumeration;
+import org.eclipse.uml2.uml.EnumerationLiteral;
+import org.eclipse.uml2.uml.Generalization;
+import org.eclipse.uml2.uml.NamedElement;
+import org.eclipse.uml2.uml.OpaqueExpression;
+import org.eclipse.uml2.uml.Package;
+import org.eclipse.uml2.uml.Property;
+import org.eclipse.uml2.uml.Stereotype;
+import org.eclipse.uml2.uml.Type;
+import org.eclipse.uml2.uml.ValueSpecification;
+import org.eclipse.uml2.uml.util.UMLSwitch;
 import org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship;
 import org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind;
 import org.openhealthtools.mdht.uml.cda.core.profile.Inline;
@@ -64,8 +81,6 @@ import org.openhealthtools.mdht.uml.term.core.profile.ValueSetConstraint;
 import org.openhealthtools.mdht.uml.term.core.profile.ValueSetVersion;
 import org.openhealthtools.mdht.uml.term.core.util.ITermProfileConstants;
 import org.openhealthtools.mdht.uml.term.core.util.TermProfileUtil;
-
-import com.google.common.collect.Constraint;
 
 public class CDAModelUtil {
 
@@ -243,10 +258,11 @@ public class CDAModelUtil {
 			String cdaName = cdaClass == null
 					? null
 					: cdaClass.getName();
-			if (cdaClass != null && ("Act".equals(cdaName) || "Encounter".equals(cdaName) ||
-					"Observation".equals(cdaName) || "ObservationMedia".equals(cdaName) ||
-					"Organizer".equals(cdaName) || "Procedure".equals(cdaName) || "RegionOfInterest".equals(cdaName) ||
-					"SubstanceAdministration".equals(cdaName) || "Supply".equals(cdaName))) {
+			if (cdaClass != null &&
+					("Act".equals(cdaName) || "Encounter".equals(cdaName) || "Observation".equals(cdaName) ||
+							"ObservationMedia".equals(cdaName) || "Organizer".equals(cdaName) ||
+							"Procedure".equals(cdaName) || "RegionOfInterest".equals(cdaName) ||
+							"SubstanceAdministration".equals(cdaName) || "Supply".equals(cdaName))) {
 				return true;
 			}
 		}
@@ -406,8 +422,8 @@ public class CDAModelUtil {
 				return multiplicityElementToggle(markup, "@extension", " [1..1]", templateVersionAsBusinessName);
 			}
 		};
-		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(
-			templateVersion).setMultiplicity(multiplicityRange).compute().toString();
+		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(templateVersion).setMultiplicity(
+			multiplicityRange).compute().toString();
 	}
 
 	public static String computeConformanceMessage(Generalization generalization, boolean markup) {
@@ -492,8 +508,8 @@ public class CDAModelUtil {
 
 	private static StringBuffer multiplicityElementToggle(Property property, boolean markup, String elementName) {
 		StringBuffer message = new StringBuffer();
-		message.append(
-			multiplicityElementToggle(markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
+		message.append(multiplicityElementToggle(
+			markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
 		return message;
 	}
 
@@ -580,12 +596,9 @@ public class CDAModelUtil {
 
 				appendConformanceRules(sb, endType, (property.getUpper() == 1
 						? "This "
-						: "Such ") +
-						(property.getUpper() == 1
-								? elementName
-								: NameUtilities.pluralize(elementName)) +
-						" ",
-					markup);
+						: "Such ") + (property.getUpper() == 1
+						? elementName
+						: NameUtilities.pluralize(elementName)) + " ", markup);
 				message.append(" " + sb + " ");
 
 			} else {
@@ -670,12 +683,9 @@ public class CDAModelUtil {
 
 				appendConformanceRules(sb, inlinedClass, (property.getUpper() == 1
 						? "This "
-						: "Such ") +
-						(property.getUpper() == 1
-								? elementName
-								: NameUtilities.pluralize(elementName)) +
-						" ",
-					markup);
+						: "Such ") + (property.getUpper() == 1
+						? elementName
+						: NameUtilities.pluralize(elementName)) + " ", markup);
 				message.append(" " + sb);
 
 			}
@@ -713,10 +723,9 @@ public class CDAModelUtil {
 			message.append("Contains ");
 			message.append(markup
 					? "<tt><b>"
-					: "").append("@typeCode=\"").append(
-						markup
-								? "</b>"
-								: "");
+					: "").append("@typeCode=\"").append(markup
+					? "</b>"
+					: "");
 			message.append(typeCode).append("\" ");
 			message.append(markup
 					? "</tt>"
@@ -801,8 +810,7 @@ public class CDAModelUtil {
 			if (eReferenceStereoetype != null) {
 				String nameSpace = (String) cdaBaseProperty.getValue(eReferenceStereoetype, CDAModelUtil.XMLNAMESPACE);
 				if (!StringUtils.isEmpty(nameSpace)) {
-					Package topPackage = org.openhealthtools.mdht.uml.common.util.UMLUtil.getTopPackage(
-						cdaBaseProperty.getNearestPackage());
+					Package topPackage = org.openhealthtools.mdht.uml.common.util.UMLUtil.getTopPackage(cdaBaseProperty.getNearestPackage());
 					Stereotype ePackageStereoetype = topPackage.getApplicableStereotype(CDAModelUtil.EPACKAGE);
 					if (ePackageStereoetype != null) {
 						if (nameSpace.equals(topPackage.getValue(ePackageStereoetype, CDAModelUtil.NSURI))) {
@@ -883,8 +891,7 @@ public class CDAModelUtil {
 		TransformProvider newContributor = null;
 		Property cdaProperty = null;
 		try {
-			newContributor = (TransformProvider) extensions[0].getConfigurationElements()[0].createExecutableExtension(
-				"transform-class");
+			newContributor = (TransformProvider) extensions[0].getConfigurationElements()[0].createExecutableExtension("transform-class");
 			cdaProperty = newContributor.GetTransform(property);
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -956,13 +963,11 @@ public class CDAModelUtil {
 					textValue, ICDAProfileConstants.VALIDATION_SEVERITY);
 				message.append(" and ").append(markup
 						? "<b>"
-						: "").append(
-							level != null
-									? getValidationKeyword(level.getLiteral())
-									: keyword).append(
-										markup
-												? "</b>"
-												: "").append(" equal \"").append(value).append("\"");
+						: "").append(level != null
+						? getValidationKeyword(level.getLiteral())
+						: keyword).append(markup
+						? "</b>"
+						: "").append(" equal \"").append(value).append("\"");
 			}
 		}
 
@@ -974,8 +979,8 @@ public class CDAModelUtil {
 				? null
 				: redefinedProperties.get(0);
 
-		if (property.getType() != null && ((redefinedProperty == null ||
-				(!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
+		if (property.getType() != null &&
+				((redefinedProperty == null || (!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
 			message.append(" with " + "@xsi:type=\"");
 			if (redefinedProperty != null && redefinedProperty.getType() != null &&
 					redefinedProperty.getType().getName() != null && !redefinedProperty.getType().getName().isEmpty()) {
@@ -1033,10 +1038,10 @@ public class CDAModelUtil {
 
 				if (isPublishSeperately((Class) property.getType())) {
 
-					String xref = (property.getType() instanceof Classifier &&
-							UMLUtil.isSameProject(property, property.getType()))
-									? computeXref(xrefSource, (Classifier) property.getType())
-									: null;
+					String xref = (property.getType() instanceof Classifier && UMLUtil.isSameProject(
+						property, property.getType()))
+							? computeXref(xrefSource, (Classifier) property.getType())
+							: null;
 					boolean showXref = markup && (xref != null);
 
 					if (showXref) {
@@ -1116,16 +1121,11 @@ public class CDAModelUtil {
 	 */
 	private static String getStereotypeName(Property cdaProperty) {
 		Stereotype eAttribute = cdaProperty.getAppliedStereotype("Ecore::EAttribute");
+		String name = null;
 		if (eAttribute != null) {
-			String name = (String) cdaProperty.getValue(eAttribute, "xmlName");
-
-			// handle the special case of ID with another name such a sectionId in Section
-			if (name != null) {
-				return name;
-			}
+			name = (String) cdaProperty.getValue(eAttribute, "xmlName");
 		}
-
-		return null;
+		return name;
 	}
 
 	private static void appendSubsetsNotation(Property property, StringBuffer message, boolean markup,
@@ -1236,15 +1236,17 @@ public class CDAModelUtil {
 
 		// XML attributes
 		for (Property property : propertyList.getAttributes()) {
-			hasRules = hasRules | appendPropertyList(
-				umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
-				subConstraintMap);
+			hasRules = hasRules |
+					appendPropertyList(
+						umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
+						subConstraintMap);
 		}
 		// XML elements
 		for (Property property : propertyList.getAssociationEnds()) {
-			hasRules = hasRules | appendPropertyList(
-				umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
-				subConstraintMap);
+			hasRules = hasRules |
+					appendPropertyList(
+						umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
+						subConstraintMap);
 		}
 
 		for (Constraint constraint : unprocessedConstraints) {
@@ -1364,8 +1366,7 @@ public class CDAModelUtil {
 	}
 
 	private static void appendSubConstraintRules(StringBuffer ruleConstraints, Constraint constraint,
-			Map<Constraint, List<Constraint>> subConstraintMap, List<Constraint> unprocessedConstraints,
-			boolean markup) {
+			Map<Constraint, List<Constraint>> subConstraintMap, List<Constraint> unprocessedConstraints, boolean markup) {
 
 		String[] ol;
 		String[] li;
@@ -1803,22 +1804,19 @@ public class CDAModelUtil {
 			String propertyKeyword = getValidationKeyword(constraint.getConstrainedElements().get(0));
 
 			if (propertyKeyword != null) {
-				message.append(
-					computeConformanceMessage(constraint.getConstrainedElements().get(0), markup).replace(
-						propertyKeyword, ""));
+				message.append(computeConformanceMessage(constraint.getConstrainedElements().get(0), markup).replace(
+					propertyKeyword, ""));
 			} else {
 				message.append(computeConformanceMessage(constraint.getConstrainedElements().get(0), markup));
 			}
 
 			message.append(" then it ").append(markup
 					? "<lines>"
-					: "").append(
-						markup
-								? "<b>"
-								: "").append(keyword).append(
-									markup
-											? "</b> "
-											: " ");
+					: "").append(markup
+					? "<b>"
+					: "").append(keyword).append(markup
+					? "</b> "
+					: " ");
 
 			message.append(computeConformanceMessage(constraint.getConstrainedElements().get(1), markup));
 			message.append(markup
@@ -2164,8 +2162,7 @@ public class CDAModelUtil {
 			elementName = "entry";
 		} else if (CDAModelUtil.isOrganizer(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
 			elementName = "component";
-		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) &&
-				CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
+		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
 			elementName = "entryRelationship";
 		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && cdaTargetClass != null &&
 				"ParticipantRole".equals(cdaTargetClass.getName())) {
@@ -2227,9 +2224,8 @@ public class CDAModelUtil {
 			if (property.getUpper() == -1) {
 				message.append("at least one");
 			} else {
-				message.append(
-					"at least " + convertNumberToWords(property.getLower()) + " and not more than " +
-							convertNumberToWords(property.getUpper()));
+				message.append("at least " + convertNumberToWords(property.getLower()) + " and not more than " +
+						convertNumberToWords(property.getUpper()));
 			}
 		} else {
 			// Lower is greater then 1

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -24,6 +24,7 @@ package org.openhealthtools.mdht.uml.cda.core.util;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,24 +47,6 @@ import org.eclipse.emf.common.util.Enumerator;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.uml2.common.util.UML2Util;
-import org.eclipse.uml2.uml.Association;
-import org.eclipse.uml2.uml.Class;
-import org.eclipse.uml2.uml.Classifier;
-import org.eclipse.uml2.uml.Comment;
-import org.eclipse.uml2.uml.Constraint;
-import org.eclipse.uml2.uml.Element;
-import org.eclipse.uml2.uml.Enumeration;
-import org.eclipse.uml2.uml.EnumerationLiteral;
-import org.eclipse.uml2.uml.Generalization;
-import org.eclipse.uml2.uml.NamedElement;
-import org.eclipse.uml2.uml.OpaqueExpression;
-import org.eclipse.uml2.uml.Package;
-import org.eclipse.uml2.uml.Property;
-import org.eclipse.uml2.uml.Stereotype;
-import org.eclipse.uml2.uml.Type;
-import org.eclipse.uml2.uml.ValueSpecification;
-import org.eclipse.uml2.uml.util.UMLSwitch;
 import org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship;
 import org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind;
 import org.openhealthtools.mdht.uml.cda.core.profile.Inline;
@@ -81,6 +64,8 @@ import org.openhealthtools.mdht.uml.term.core.profile.ValueSetConstraint;
 import org.openhealthtools.mdht.uml.term.core.profile.ValueSetVersion;
 import org.openhealthtools.mdht.uml.term.core.util.ITermProfileConstants;
 import org.openhealthtools.mdht.uml.term.core.util.TermProfileUtil;
+
+import com.google.common.collect.Constraint;
 
 public class CDAModelUtil {
 
@@ -1112,7 +1097,7 @@ public class CDAModelUtil {
 			return name;
 		}
 
-		// if there are redefines, check for more but only alone the first branch (0)
+		// if there are redefines, check for more but only along the first branch (0)
 		if (redefines != null && redefines.size() > 0) {
 			return getCDAName(redefines.get(0));
 		}

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -258,11 +258,10 @@ public class CDAModelUtil {
 			String cdaName = cdaClass == null
 					? null
 					: cdaClass.getName();
-			if (cdaClass != null &&
-					("Act".equals(cdaName) || "Encounter".equals(cdaName) || "Observation".equals(cdaName) ||
-							"ObservationMedia".equals(cdaName) || "Organizer".equals(cdaName) ||
-							"Procedure".equals(cdaName) || "RegionOfInterest".equals(cdaName) ||
-							"SubstanceAdministration".equals(cdaName) || "Supply".equals(cdaName))) {
+			if (cdaClass != null && ("Act".equals(cdaName) || "Encounter".equals(cdaName) ||
+					"Observation".equals(cdaName) || "ObservationMedia".equals(cdaName) ||
+					"Organizer".equals(cdaName) || "Procedure".equals(cdaName) || "RegionOfInterest".equals(cdaName) ||
+					"SubstanceAdministration".equals(cdaName) || "Supply".equals(cdaName))) {
 				return true;
 			}
 		}
@@ -422,8 +421,8 @@ public class CDAModelUtil {
 				return multiplicityElementToggle(markup, "@extension", " [1..1]", templateVersionAsBusinessName);
 			}
 		};
-		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(templateVersion).setMultiplicity(
-			multiplicityRange).compute().toString();
+		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(
+			templateVersion).setMultiplicity(multiplicityRange).compute().toString();
 	}
 
 	public static String computeConformanceMessage(Generalization generalization, boolean markup) {
@@ -508,8 +507,8 @@ public class CDAModelUtil {
 
 	private static StringBuffer multiplicityElementToggle(Property property, boolean markup, String elementName) {
 		StringBuffer message = new StringBuffer();
-		message.append(multiplicityElementToggle(
-			markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
+		message.append(
+			multiplicityElementToggle(markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
 		return message;
 	}
 
@@ -596,9 +595,12 @@ public class CDAModelUtil {
 
 				appendConformanceRules(sb, endType, (property.getUpper() == 1
 						? "This "
-						: "Such ") + (property.getUpper() == 1
-						? elementName
-						: NameUtilities.pluralize(elementName)) + " ", markup);
+						: "Such ") +
+						(property.getUpper() == 1
+								? elementName
+								: NameUtilities.pluralize(elementName)) +
+						" ",
+					markup);
 				message.append(" " + sb + " ");
 
 			} else {
@@ -683,9 +685,12 @@ public class CDAModelUtil {
 
 				appendConformanceRules(sb, inlinedClass, (property.getUpper() == 1
 						? "This "
-						: "Such ") + (property.getUpper() == 1
-						? elementName
-						: NameUtilities.pluralize(elementName)) + " ", markup);
+						: "Such ") +
+						(property.getUpper() == 1
+								? elementName
+								: NameUtilities.pluralize(elementName)) +
+						" ",
+					markup);
 				message.append(" " + sb);
 
 			}
@@ -723,9 +728,10 @@ public class CDAModelUtil {
 			message.append("Contains ");
 			message.append(markup
 					? "<tt><b>"
-					: "").append("@typeCode=\"").append(markup
-					? "</b>"
-					: "");
+					: "").append("@typeCode=\"").append(
+						markup
+								? "</b>"
+								: "");
 			message.append(typeCode).append("\" ");
 			message.append(markup
 					? "</tt>"
@@ -810,7 +816,8 @@ public class CDAModelUtil {
 			if (eReferenceStereoetype != null) {
 				String nameSpace = (String) cdaBaseProperty.getValue(eReferenceStereoetype, CDAModelUtil.XMLNAMESPACE);
 				if (!StringUtils.isEmpty(nameSpace)) {
-					Package topPackage = org.openhealthtools.mdht.uml.common.util.UMLUtil.getTopPackage(cdaBaseProperty.getNearestPackage());
+					Package topPackage = org.openhealthtools.mdht.uml.common.util.UMLUtil.getTopPackage(
+						cdaBaseProperty.getNearestPackage());
 					Stereotype ePackageStereoetype = topPackage.getApplicableStereotype(CDAModelUtil.EPACKAGE);
 					if (ePackageStereoetype != null) {
 						if (nameSpace.equals(topPackage.getValue(ePackageStereoetype, CDAModelUtil.NSURI))) {
@@ -891,7 +898,8 @@ public class CDAModelUtil {
 		TransformProvider newContributor = null;
 		Property cdaProperty = null;
 		try {
-			newContributor = (TransformProvider) extensions[0].getConfigurationElements()[0].createExecutableExtension("transform-class");
+			newContributor = (TransformProvider) extensions[0].getConfigurationElements()[0].createExecutableExtension(
+				"transform-class");
 			cdaProperty = newContributor.GetTransform(property);
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -963,11 +971,13 @@ public class CDAModelUtil {
 					textValue, ICDAProfileConstants.VALIDATION_SEVERITY);
 				message.append(" and ").append(markup
 						? "<b>"
-						: "").append(level != null
-						? getValidationKeyword(level.getLiteral())
-						: keyword).append(markup
-						? "</b>"
-						: "").append(" equal \"").append(value).append("\"");
+						: "").append(
+							level != null
+									? getValidationKeyword(level.getLiteral())
+									: keyword).append(
+										markup
+												? "</b>"
+												: "").append(" equal \"").append(value).append("\"");
 			}
 		}
 
@@ -979,8 +989,8 @@ public class CDAModelUtil {
 				? null
 				: redefinedProperties.get(0);
 
-		if (property.getType() != null &&
-				((redefinedProperty == null || (!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
+		if (property.getType() != null && ((redefinedProperty == null ||
+				(!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
 			message.append(" with " + "@xsi:type=\"");
 			if (redefinedProperty != null && redefinedProperty.getType() != null &&
 					redefinedProperty.getType().getName() != null && !redefinedProperty.getType().getName().isEmpty()) {
@@ -1038,10 +1048,10 @@ public class CDAModelUtil {
 
 				if (isPublishSeperately((Class) property.getType())) {
 
-					String xref = (property.getType() instanceof Classifier && UMLUtil.isSameProject(
-						property, property.getType()))
-							? computeXref(xrefSource, (Classifier) property.getType())
-							: null;
+					String xref = (property.getType() instanceof Classifier &&
+							UMLUtil.isSameProject(property, property.getType()))
+									? computeXref(xrefSource, (Classifier) property.getType())
+									: null;
 					boolean showXref = markup && (xref != null);
 
 					if (showXref) {
@@ -1236,17 +1246,15 @@ public class CDAModelUtil {
 
 		// XML attributes
 		for (Property property : propertyList.getAttributes()) {
-			hasRules = hasRules |
-					appendPropertyList(
-						umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
-						subConstraintMap);
+			hasRules = hasRules | appendPropertyList(
+				umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
+				subConstraintMap);
 		}
 		// XML elements
 		for (Property property : propertyList.getAssociationEnds()) {
-			hasRules = hasRules |
-					appendPropertyList(
-						umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
-						subConstraintMap);
+			hasRules = hasRules | appendPropertyList(
+				umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
+				subConstraintMap);
 		}
 
 		for (Constraint constraint : unprocessedConstraints) {
@@ -1366,7 +1374,8 @@ public class CDAModelUtil {
 	}
 
 	private static void appendSubConstraintRules(StringBuffer ruleConstraints, Constraint constraint,
-			Map<Constraint, List<Constraint>> subConstraintMap, List<Constraint> unprocessedConstraints, boolean markup) {
+			Map<Constraint, List<Constraint>> subConstraintMap, List<Constraint> unprocessedConstraints,
+			boolean markup) {
 
 		String[] ol;
 		String[] li;
@@ -1804,19 +1813,22 @@ public class CDAModelUtil {
 			String propertyKeyword = getValidationKeyword(constraint.getConstrainedElements().get(0));
 
 			if (propertyKeyword != null) {
-				message.append(computeConformanceMessage(constraint.getConstrainedElements().get(0), markup).replace(
-					propertyKeyword, ""));
+				message.append(
+					computeConformanceMessage(constraint.getConstrainedElements().get(0), markup).replace(
+						propertyKeyword, ""));
 			} else {
 				message.append(computeConformanceMessage(constraint.getConstrainedElements().get(0), markup));
 			}
 
 			message.append(" then it ").append(markup
 					? "<lines>"
-					: "").append(markup
-					? "<b>"
-					: "").append(keyword).append(markup
-					? "</b> "
-					: " ");
+					: "").append(
+						markup
+								? "<b>"
+								: "").append(keyword).append(
+									markup
+											? "</b> "
+											: " ");
 
 			message.append(computeConformanceMessage(constraint.getConstrainedElements().get(1), markup));
 			message.append(markup
@@ -2162,7 +2174,8 @@ public class CDAModelUtil {
 			elementName = "entry";
 		} else if (CDAModelUtil.isOrganizer(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
 			elementName = "component";
-		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
+		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) &&
+				CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
 			elementName = "entryRelationship";
 		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && cdaTargetClass != null &&
 				"ParticipantRole".equals(cdaTargetClass.getName())) {
@@ -2224,8 +2237,9 @@ public class CDAModelUtil {
 			if (property.getUpper() == -1) {
 				message.append("at least one");
 			} else {
-				message.append("at least " + convertNumberToWords(property.getLower()) + " and not more than " +
-						convertNumberToWords(property.getUpper()));
+				message.append(
+					"at least " + convertNumberToWords(property.getLower()) + " and not more than " +
+							convertNumberToWords(property.getUpper()));
 			}
 		} else {
 			// Lower is greater then 1

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -24,6 +24,7 @@ package org.openhealthtools.mdht.uml.cda.core.util;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,24 +47,6 @@ import org.eclipse.emf.common.util.Enumerator;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.uml2.common.util.UML2Util;
-import org.eclipse.uml2.uml.Association;
-import org.eclipse.uml2.uml.Class;
-import org.eclipse.uml2.uml.Classifier;
-import org.eclipse.uml2.uml.Comment;
-import org.eclipse.uml2.uml.Constraint;
-import org.eclipse.uml2.uml.Element;
-import org.eclipse.uml2.uml.Enumeration;
-import org.eclipse.uml2.uml.EnumerationLiteral;
-import org.eclipse.uml2.uml.Generalization;
-import org.eclipse.uml2.uml.NamedElement;
-import org.eclipse.uml2.uml.OpaqueExpression;
-import org.eclipse.uml2.uml.Package;
-import org.eclipse.uml2.uml.Property;
-import org.eclipse.uml2.uml.Stereotype;
-import org.eclipse.uml2.uml.Type;
-import org.eclipse.uml2.uml.ValueSpecification;
-import org.eclipse.uml2.uml.util.UMLSwitch;
 import org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationship;
 import org.openhealthtools.mdht.uml.cda.core.profile.EntryRelationshipKind;
 import org.openhealthtools.mdht.uml.cda.core.profile.Inline;
@@ -81,6 +64,8 @@ import org.openhealthtools.mdht.uml.term.core.profile.ValueSetConstraint;
 import org.openhealthtools.mdht.uml.term.core.profile.ValueSetVersion;
 import org.openhealthtools.mdht.uml.term.core.util.ITermProfileConstants;
 import org.openhealthtools.mdht.uml.term.core.util.TermProfileUtil;
+
+import com.google.common.collect.Constraint;
 
 public class CDAModelUtil {
 
@@ -258,11 +243,10 @@ public class CDAModelUtil {
 			String cdaName = cdaClass == null
 					? null
 					: cdaClass.getName();
-			if (cdaClass != null &&
-					("Act".equals(cdaName) || "Encounter".equals(cdaName) || "Observation".equals(cdaName) ||
-							"ObservationMedia".equals(cdaName) || "Organizer".equals(cdaName) ||
-							"Procedure".equals(cdaName) || "RegionOfInterest".equals(cdaName) ||
-							"SubstanceAdministration".equals(cdaName) || "Supply".equals(cdaName))) {
+			if (cdaClass != null && ("Act".equals(cdaName) || "Encounter".equals(cdaName) ||
+					"Observation".equals(cdaName) || "ObservationMedia".equals(cdaName) ||
+					"Organizer".equals(cdaName) || "Procedure".equals(cdaName) || "RegionOfInterest".equals(cdaName) ||
+					"SubstanceAdministration".equals(cdaName) || "Supply".equals(cdaName))) {
 				return true;
 			}
 		}
@@ -422,8 +406,8 @@ public class CDAModelUtil {
 				return multiplicityElementToggle(markup, "@extension", " [1..1]", templateVersionAsBusinessName);
 			}
 		};
-		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(templateVersion).setMultiplicity(
-			multiplicityRange).compute().toString();
+		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(
+			templateVersion).setMultiplicity(multiplicityRange).compute().toString();
 	}
 
 	public static String computeConformanceMessage(Generalization generalization, boolean markup) {
@@ -508,8 +492,8 @@ public class CDAModelUtil {
 
 	private static StringBuffer multiplicityElementToggle(Property property, boolean markup, String elementName) {
 		StringBuffer message = new StringBuffer();
-		message.append(multiplicityElementToggle(
-			markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
+		message.append(
+			multiplicityElementToggle(markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
 		return message;
 	}
 
@@ -596,9 +580,12 @@ public class CDAModelUtil {
 
 				appendConformanceRules(sb, endType, (property.getUpper() == 1
 						? "This "
-						: "Such ") + (property.getUpper() == 1
-						? elementName
-						: NameUtilities.pluralize(elementName)) + " ", markup);
+						: "Such ") +
+						(property.getUpper() == 1
+								? elementName
+								: NameUtilities.pluralize(elementName)) +
+						" ",
+					markup);
 				message.append(" " + sb + " ");
 
 			} else {
@@ -683,9 +670,12 @@ public class CDAModelUtil {
 
 				appendConformanceRules(sb, inlinedClass, (property.getUpper() == 1
 						? "This "
-						: "Such ") + (property.getUpper() == 1
-						? elementName
-						: NameUtilities.pluralize(elementName)) + " ", markup);
+						: "Such ") +
+						(property.getUpper() == 1
+								? elementName
+								: NameUtilities.pluralize(elementName)) +
+						" ",
+					markup);
 				message.append(" " + sb);
 
 			}
@@ -723,9 +713,10 @@ public class CDAModelUtil {
 			message.append("Contains ");
 			message.append(markup
 					? "<tt><b>"
-					: "").append("@typeCode=\"").append(markup
-					? "</b>"
-					: "");
+					: "").append("@typeCode=\"").append(
+						markup
+								? "</b>"
+								: "");
 			message.append(typeCode).append("\" ");
 			message.append(markup
 					? "</tt>"
@@ -810,7 +801,8 @@ public class CDAModelUtil {
 			if (eReferenceStereoetype != null) {
 				String nameSpace = (String) cdaBaseProperty.getValue(eReferenceStereoetype, CDAModelUtil.XMLNAMESPACE);
 				if (!StringUtils.isEmpty(nameSpace)) {
-					Package topPackage = org.openhealthtools.mdht.uml.common.util.UMLUtil.getTopPackage(cdaBaseProperty.getNearestPackage());
+					Package topPackage = org.openhealthtools.mdht.uml.common.util.UMLUtil.getTopPackage(
+						cdaBaseProperty.getNearestPackage());
 					Stereotype ePackageStereoetype = topPackage.getApplicableStereotype(CDAModelUtil.EPACKAGE);
 					if (ePackageStereoetype != null) {
 						if (nameSpace.equals(topPackage.getValue(ePackageStereoetype, CDAModelUtil.NSURI))) {
@@ -891,7 +883,8 @@ public class CDAModelUtil {
 		TransformProvider newContributor = null;
 		Property cdaProperty = null;
 		try {
-			newContributor = (TransformProvider) extensions[0].getConfigurationElements()[0].createExecutableExtension("transform-class");
+			newContributor = (TransformProvider) extensions[0].getConfigurationElements()[0].createExecutableExtension(
+				"transform-class");
 			cdaProperty = newContributor.GetTransform(property);
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -963,11 +956,13 @@ public class CDAModelUtil {
 					textValue, ICDAProfileConstants.VALIDATION_SEVERITY);
 				message.append(" and ").append(markup
 						? "<b>"
-						: "").append(level != null
-						? getValidationKeyword(level.getLiteral())
-						: keyword).append(markup
-						? "</b>"
-						: "").append(" equal \"").append(value).append("\"");
+						: "").append(
+							level != null
+									? getValidationKeyword(level.getLiteral())
+									: keyword).append(
+										markup
+												? "</b>"
+												: "").append(" equal \"").append(value).append("\"");
 			}
 		}
 
@@ -979,8 +974,8 @@ public class CDAModelUtil {
 				? null
 				: redefinedProperties.get(0);
 
-		if (property.getType() != null &&
-				((redefinedProperty == null || (!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
+		if (property.getType() != null && ((redefinedProperty == null ||
+				(!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
 			message.append(" with " + "@xsi:type=\"");
 			if (redefinedProperty != null && redefinedProperty.getType() != null &&
 					redefinedProperty.getType().getName() != null && !redefinedProperty.getType().getName().isEmpty()) {
@@ -1038,10 +1033,10 @@ public class CDAModelUtil {
 
 				if (isPublishSeperately((Class) property.getType())) {
 
-					String xref = (property.getType() instanceof Classifier && UMLUtil.isSameProject(
-						property, property.getType()))
-							? computeXref(xrefSource, (Classifier) property.getType())
-							: null;
+					String xref = (property.getType() instanceof Classifier &&
+							UMLUtil.isSameProject(property, property.getType()))
+									? computeXref(xrefSource, (Classifier) property.getType())
+									: null;
 					boolean showXref = markup && (xref != null);
 
 					if (showXref) {
@@ -1098,8 +1093,9 @@ public class CDAModelUtil {
 
 		// if there is a stereotype name, use it
 		String name = getStereotypeName(cdaProperty);
-		if (name != null)
+		if (name != null) {
 			return name;
+		}
 
 		// if there are redefines, check for more but only alone the first branch (0)
 		if (redefines != null && redefines.size() > 0) {
@@ -1240,17 +1236,15 @@ public class CDAModelUtil {
 
 		// XML attributes
 		for (Property property : propertyList.getAttributes()) {
-			hasRules = hasRules |
-					appendPropertyList(
-						umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
-						subConstraintMap);
+			hasRules = hasRules | appendPropertyList(
+				umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
+				subConstraintMap);
 		}
 		// XML elements
 		for (Property property : propertyList.getAssociationEnds()) {
-			hasRules = hasRules |
-					appendPropertyList(
-						umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
-						subConstraintMap);
+			hasRules = hasRules | appendPropertyList(
+				umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
+				subConstraintMap);
 		}
 
 		for (Constraint constraint : unprocessedConstraints) {
@@ -1370,7 +1364,8 @@ public class CDAModelUtil {
 	}
 
 	private static void appendSubConstraintRules(StringBuffer ruleConstraints, Constraint constraint,
-			Map<Constraint, List<Constraint>> subConstraintMap, List<Constraint> unprocessedConstraints, boolean markup) {
+			Map<Constraint, List<Constraint>> subConstraintMap, List<Constraint> unprocessedConstraints,
+			boolean markup) {
 
 		String[] ol;
 		String[] li;
@@ -1808,19 +1803,22 @@ public class CDAModelUtil {
 			String propertyKeyword = getValidationKeyword(constraint.getConstrainedElements().get(0));
 
 			if (propertyKeyword != null) {
-				message.append(computeConformanceMessage(constraint.getConstrainedElements().get(0), markup).replace(
-					propertyKeyword, ""));
+				message.append(
+					computeConformanceMessage(constraint.getConstrainedElements().get(0), markup).replace(
+						propertyKeyword, ""));
 			} else {
 				message.append(computeConformanceMessage(constraint.getConstrainedElements().get(0), markup));
 			}
 
 			message.append(" then it ").append(markup
 					? "<lines>"
-					: "").append(markup
-					? "<b>"
-					: "").append(keyword).append(markup
-					? "</b> "
-					: " ");
+					: "").append(
+						markup
+								? "<b>"
+								: "").append(keyword).append(
+									markup
+											? "</b> "
+											: " ");
 
 			message.append(computeConformanceMessage(constraint.getConstrainedElements().get(1), markup));
 			message.append(markup
@@ -2166,7 +2164,8 @@ public class CDAModelUtil {
 			elementName = "entry";
 		} else if (CDAModelUtil.isOrganizer(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
 			elementName = "component";
-		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
+		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) &&
+				CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
 			elementName = "entryRelationship";
 		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && cdaTargetClass != null &&
 				"ParticipantRole".equals(cdaTargetClass.getName())) {
@@ -2228,8 +2227,9 @@ public class CDAModelUtil {
 			if (property.getUpper() == -1) {
 				message.append("at least one");
 			} else {
-				message.append("at least " + convertNumberToWords(property.getLower()) + " and not more than " +
-						convertNumberToWords(property.getUpper()));
+				message.append(
+					"at least " + convertNumberToWords(property.getLower()) + " and not more than " +
+							convertNumberToWords(property.getUpper()));
 			}
 		} else {
 			// Lower is greater then 1

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -41,6 +41,7 @@ import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.Enumerator;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
@@ -257,10 +258,11 @@ public class CDAModelUtil {
 			String cdaName = cdaClass == null
 					? null
 					: cdaClass.getName();
-			if (cdaClass != null && ("Act".equals(cdaName) || "Encounter".equals(cdaName) ||
-					"Observation".equals(cdaName) || "ObservationMedia".equals(cdaName) ||
-					"Organizer".equals(cdaName) || "Procedure".equals(cdaName) || "RegionOfInterest".equals(cdaName) ||
-					"SubstanceAdministration".equals(cdaName) || "Supply".equals(cdaName))) {
+			if (cdaClass != null &&
+					("Act".equals(cdaName) || "Encounter".equals(cdaName) || "Observation".equals(cdaName) ||
+							"ObservationMedia".equals(cdaName) || "Organizer".equals(cdaName) ||
+							"Procedure".equals(cdaName) || "RegionOfInterest".equals(cdaName) ||
+							"SubstanceAdministration".equals(cdaName) || "Supply".equals(cdaName))) {
 				return true;
 			}
 		}
@@ -420,8 +422,8 @@ public class CDAModelUtil {
 				return multiplicityElementToggle(markup, "@extension", " [1..1]", templateVersionAsBusinessName);
 			}
 		};
-		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(
-			templateVersion).setMultiplicity(multiplicityRange).compute().toString();
+		return cdaTemplater.setRequireMarkup(markup).setRuleIds(ruleIds).setTemplateVersion(templateVersion).setMultiplicity(
+			multiplicityRange).compute().toString();
 	}
 
 	public static String computeConformanceMessage(Generalization generalization, boolean markup) {
@@ -506,8 +508,8 @@ public class CDAModelUtil {
 
 	private static StringBuffer multiplicityElementToggle(Property property, boolean markup, String elementName) {
 		StringBuffer message = new StringBuffer();
-		message.append(
-			multiplicityElementToggle(markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
+		message.append(multiplicityElementToggle(
+			markup, elementName, getMultiplicityRange(property), getBusinessName(property)));
 		return message;
 	}
 
@@ -594,12 +596,9 @@ public class CDAModelUtil {
 
 				appendConformanceRules(sb, endType, (property.getUpper() == 1
 						? "This "
-						: "Such ") +
-						(property.getUpper() == 1
-								? elementName
-								: NameUtilities.pluralize(elementName)) +
-						" ",
-					markup);
+						: "Such ") + (property.getUpper() == 1
+						? elementName
+						: NameUtilities.pluralize(elementName)) + " ", markup);
 				message.append(" " + sb + " ");
 
 			} else {
@@ -684,12 +683,9 @@ public class CDAModelUtil {
 
 				appendConformanceRules(sb, inlinedClass, (property.getUpper() == 1
 						? "This "
-						: "Such ") +
-						(property.getUpper() == 1
-								? elementName
-								: NameUtilities.pluralize(elementName)) +
-						" ",
-					markup);
+						: "Such ") + (property.getUpper() == 1
+						? elementName
+						: NameUtilities.pluralize(elementName)) + " ", markup);
 				message.append(" " + sb);
 
 			}
@@ -727,10 +723,9 @@ public class CDAModelUtil {
 			message.append("Contains ");
 			message.append(markup
 					? "<tt><b>"
-					: "").append("@typeCode=\"").append(
-						markup
-								? "</b>"
-								: "");
+					: "").append("@typeCode=\"").append(markup
+					? "</b>"
+					: "");
 			message.append(typeCode).append("\" ");
 			message.append(markup
 					? "</tt>"
@@ -815,8 +810,7 @@ public class CDAModelUtil {
 			if (eReferenceStereoetype != null) {
 				String nameSpace = (String) cdaBaseProperty.getValue(eReferenceStereoetype, CDAModelUtil.XMLNAMESPACE);
 				if (!StringUtils.isEmpty(nameSpace)) {
-					Package topPackage = org.openhealthtools.mdht.uml.common.util.UMLUtil.getTopPackage(
-						cdaBaseProperty.getNearestPackage());
+					Package topPackage = org.openhealthtools.mdht.uml.common.util.UMLUtil.getTopPackage(cdaBaseProperty.getNearestPackage());
 					Stereotype ePackageStereoetype = topPackage.getApplicableStereotype(CDAModelUtil.EPACKAGE);
 					if (ePackageStereoetype != null) {
 						if (nameSpace.equals(topPackage.getValue(ePackageStereoetype, CDAModelUtil.NSURI))) {
@@ -897,8 +891,7 @@ public class CDAModelUtil {
 		TransformProvider newContributor = null;
 		Property cdaProperty = null;
 		try {
-			newContributor = (TransformProvider) extensions[0].getConfigurationElements()[0].createExecutableExtension(
-				"transform-class");
+			newContributor = (TransformProvider) extensions[0].getConfigurationElements()[0].createExecutableExtension("transform-class");
 			cdaProperty = newContributor.GetTransform(property);
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -906,7 +899,7 @@ public class CDAModelUtil {
 
 		String propertyCdaName = null;
 		if (cdaProperty != null) {
-			propertyCdaName = cdaProperty.getName();
+			propertyCdaName = getCDAName(cdaProperty);
 		} else {
 			propertyCdaName = getCDAElementName(property);
 		}
@@ -970,13 +963,11 @@ public class CDAModelUtil {
 					textValue, ICDAProfileConstants.VALIDATION_SEVERITY);
 				message.append(" and ").append(markup
 						? "<b>"
-						: "").append(
-							level != null
-									? getValidationKeyword(level.getLiteral())
-									: keyword).append(
-										markup
-												? "</b>"
-												: "").append(" equal \"").append(value).append("\"");
+						: "").append(level != null
+						? getValidationKeyword(level.getLiteral())
+						: keyword).append(markup
+						? "</b>"
+						: "").append(" equal \"").append(value).append("\"");
 			}
 		}
 
@@ -988,8 +979,8 @@ public class CDAModelUtil {
 				? null
 				: redefinedProperties.get(0);
 
-		if (property.getType() != null && ((redefinedProperty == null ||
-				(!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
+		if (property.getType() != null &&
+				((redefinedProperty == null || (!isXMLAttribute(property) && (property.getType() != redefinedProperty.getType()))))) {
 			message.append(" with " + "@xsi:type=\"");
 			if (redefinedProperty != null && redefinedProperty.getType() != null &&
 					redefinedProperty.getType().getName() != null && !redefinedProperty.getType().getName().isEmpty()) {
@@ -1047,10 +1038,10 @@ public class CDAModelUtil {
 
 				if (isPublishSeperately((Class) property.getType())) {
 
-					String xref = (property.getType() instanceof Classifier &&
-							UMLUtil.isSameProject(property, property.getType()))
-									? computeXref(xrefSource, (Classifier) property.getType())
-									: null;
+					String xref = (property.getType() instanceof Classifier && UMLUtil.isSameProject(
+						property, property.getType()))
+							? computeXref(xrefSource, (Classifier) property.getType())
+							: null;
 					boolean showXref = markup && (xref != null);
 
 					if (showXref) {
@@ -1087,6 +1078,58 @@ public class CDAModelUtil {
 		}
 
 		return message.toString();
+	}
+
+	/**
+	 * getCDAName
+	 *
+	 * recursively, depth first, check the object graph for a CDA Name using the root of the "redefined"
+	 * property if it exists.
+	 *
+	 * Also handle special cases like sectionId which has a cdaName of ID
+	 *
+	 * @param cdaProperty
+	 *            an MDHT property
+	 * @return string
+	 *         the calculated CDA name
+	 */
+	private static String getCDAName(Property cdaProperty) {
+		EList<Property> redefines = cdaProperty.getRedefinedProperties();
+
+		// if there is a stereotype name, use it
+		String name = getStereotypeName(cdaProperty);
+		if (name != null)
+			return name;
+
+		// if there are redefines, check for more but only alone the first branch (0)
+		if (redefines != null && redefines.size() > 0) {
+			return getCDAName(redefines.get(0));
+		}
+
+		// eventually return the property Name of the root redefined element;
+
+		return cdaProperty.getName();
+	}
+
+	/**
+	 * Get the CDA name from a stereotype if it exists
+	 *
+	 * @param cdaProperty
+	 *            a Property
+	 * @return the xmlName or null if no stereotype exists
+	 */
+	private static String getStereotypeName(Property cdaProperty) {
+		Stereotype eAttribute = cdaProperty.getAppliedStereotype("Ecore::EAttribute");
+		if (eAttribute != null) {
+			String name = (String) cdaProperty.getValue(eAttribute, "xmlName");
+
+			// handle the special case of ID with another name such a sectionId in Section
+			if (name != null) {
+				return name;
+			}
+		}
+
+		return null;
 	}
 
 	private static void appendSubsetsNotation(Property property, StringBuffer message, boolean markup,
@@ -1197,15 +1240,17 @@ public class CDAModelUtil {
 
 		// XML attributes
 		for (Property property : propertyList.getAttributes()) {
-			hasRules = hasRules | appendPropertyList(
-				umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
-				subConstraintMap);
+			hasRules = hasRules |
+					appendPropertyList(
+						umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
+						subConstraintMap);
 		}
 		// XML elements
 		for (Property property : propertyList.getAssociationEnds()) {
-			hasRules = hasRules | appendPropertyList(
-				umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
-				subConstraintMap);
+			hasRules = hasRules |
+					appendPropertyList(
+						umlClass, property, markup, ol, sb, prefix, li, constraintMap, unprocessedConstraints,
+						subConstraintMap);
 		}
 
 		for (Constraint constraint : unprocessedConstraints) {
@@ -1325,8 +1370,7 @@ public class CDAModelUtil {
 	}
 
 	private static void appendSubConstraintRules(StringBuffer ruleConstraints, Constraint constraint,
-			Map<Constraint, List<Constraint>> subConstraintMap, List<Constraint> unprocessedConstraints,
-			boolean markup) {
+			Map<Constraint, List<Constraint>> subConstraintMap, List<Constraint> unprocessedConstraints, boolean markup) {
 
 		String[] ol;
 		String[] li;
@@ -1764,22 +1808,19 @@ public class CDAModelUtil {
 			String propertyKeyword = getValidationKeyword(constraint.getConstrainedElements().get(0));
 
 			if (propertyKeyword != null) {
-				message.append(
-					computeConformanceMessage(constraint.getConstrainedElements().get(0), markup).replace(
-						propertyKeyword, ""));
+				message.append(computeConformanceMessage(constraint.getConstrainedElements().get(0), markup).replace(
+					propertyKeyword, ""));
 			} else {
 				message.append(computeConformanceMessage(constraint.getConstrainedElements().get(0), markup));
 			}
 
 			message.append(" then it ").append(markup
 					? "<lines>"
-					: "").append(
-						markup
-								? "<b>"
-								: "").append(keyword).append(
-									markup
-											? "</b> "
-											: " ");
+					: "").append(markup
+					? "<b>"
+					: "").append(keyword).append(markup
+					? "</b> "
+					: " ");
 
 			message.append(computeConformanceMessage(constraint.getConstrainedElements().get(1), markup));
 			message.append(markup
@@ -2125,8 +2166,7 @@ public class CDAModelUtil {
 			elementName = "entry";
 		} else if (CDAModelUtil.isOrganizer(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
 			elementName = "component";
-		} else
-			if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
+		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && CDAModelUtil.isClinicalStatement(cdaTargetClass)) {
 			elementName = "entryRelationship";
 		} else if (CDAModelUtil.isClinicalStatement(cdaSourceClass) && cdaTargetClass != null &&
 				"ParticipantRole".equals(cdaTargetClass.getName())) {
@@ -2188,9 +2228,8 @@ public class CDAModelUtil {
 			if (property.getUpper() == -1) {
 				message.append("at least one");
 			} else {
-				message.append(
-					"at least " + convertNumberToWords(property.getLower()) + " and not more than " +
-							convertNumberToWords(property.getUpper()));
+				message.append("at least " + convertNumberToWords(property.getLower()) + " and not more than " +
+						convertNumberToWords(property.getUpper()));
 			}
 		} else {
 			// Lower is greater then 1


### PR DESCRIPTION
There are some instances where DITA generation would not use the CDA name of the elements such as redefined elements and IDs. This manifested as an incorrectly named attribute in the Dita file.

![screenshot-3](https://cloud.githubusercontent.com/assets/15042244/11083925/a07ed11a-8880-11e5-84af-516236ae9809.png)

The fix addresses that issue :
![selection_099](https://cloud.githubusercontent.com/assets/15042244/11083967/120cd480-8881-11e5-8f0e-cb4f28544072.png)

and also the case where the model name does not explicitly follow cda name as in Section.sectionID

![selection_100](https://cloud.githubusercontent.com/assets/15042244/11083991/8e646e30-8881-11e5-97cc-462c83e59424.png)
