### PR TITLE
Fix duplicate conformance messages appearing in the DITA file

### DIFF
--- a/core/plugins/org.openhealthtools.mdht.uml.common/src/org/openhealthtools/mdht/uml/common/util/PropertyList.java
+++ b/core/plugins/org.openhealthtools.mdht.uml.common/src/org/openhealthtools/mdht/uml/common/util/PropertyList.java
@@ -99,6 +99,16 @@ public class PropertyList {
 			}
 
 		}
+		if (associationEnds != null) {
+			for (Property attribute : associationEnds) {
+				for (Property redefinedProperty : attribute.getRedefinedProperties()) {
+					if (property.equals(redefinedProperty)) {
+						return true;
+					}
+				}
+			}
+
+		}
 		return false;
 	}
 


### PR DESCRIPTION
In some instances generating a Dita file with a redefined property caused two conformance messages to be printed. 

changes to PropertyList.java now account for properties stored in two different arrays - attributes and associationEnds 

with this change properties that have been redefined are correctly filtered.
