### PR TITLE
CITIE-810: Some xs:attribute in the nehta extension classes don't get published correctly in DITA

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -1147,7 +1147,7 @@ public class CDAModelUtil {
 
 		// if there is a stereotype name, use it
 		String name = getStereotypeName(cdaProperty);
-		if (name != null) {
+		if (name != null && !name.isEmpty()) {
 			return name;
 		}
 


### PR DESCRIPTION
Some of the xs:attribute in the nehta extension classes don't get published correctly in DITA. E.g. classCode and negationInd in ControlAct.
