### PR TITLE
CITS-28--23-12-15

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/CDAModelUtil.java
@@ -150,7 +150,8 @@ public class CDAModelUtil {
 
 		for (Classifier parent : templateProperty.getClass_().allParents()) {
 			for (Property inherited : parent.getAttributes()) {
-				if (inherited.getName() != null && inherited.getName().equals(templateProperty.getName()) &&
+				if (inherited.getName() != null &&
+						inherited.getName().equals(ClinicalDocumentCreator.withoutDigits(templateProperty.getName())) &&
 						(isCDAModel(inherited) || isDatatypeModel(inherited))) {
 					return inherited;
 				}

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/ClinicalDocumentCreator.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.core/src/org/openhealthtools/mdht/uml/cda/core/util/ClinicalDocumentCreator.java
@@ -682,7 +682,7 @@ public class ClinicalDocumentCreator {
 	 * @param name
 	 * @return
 	 */
-	private static String withoutDigits(String name) {
+	public static String withoutDigits(String name) {
 		while (!"".equals(name) && Character.isDigit(name.charAt(name.length() - 1))) {
 			name = name.substring(0, name.length() - 1);
 		}


### PR DESCRIPTION
CITS-28: Missing prefix in DITA/PDF for child elements of extension.
The child elements of extension classes must also have the prefix ext: in their element name.

This is how it previously looked before fix:
![prev](https://cloud.githubusercontent.com/assets/11734881/11996332/ce6e02b0-aa60-11e5-857a-083bb0dcc78a.jpg)

How it looks like this after fix:
![after](https://cloud.githubusercontent.com/assets/11734881/11996336/e38dabbe-aa60-11e5-9ebc-2748781fedbc.jpg)
