### PR TITLE
Incorporate changes for the Schematron generator into the original OCL

### DIFF
--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.transform/src/org/openhealthtools/mdht/uml/cda/transform/TransformCDAAssociation.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.transform/src/org/openhealthtools/mdht/uml/cda/transform/TransformCDAAssociation.java
@@ -180,7 +180,8 @@ public class TransformCDAAssociation extends TransformAssociation {
 			if (property != null) {
 				associationEndOut[0] = property.getName();
 
-				variableDeclarationOut[0] = property.getName() + " : cda::" + property.getType().getName();
+				// CHANGE6: don't hard-code "cda::" as it could be in a sub-package, so use getQualifiedName instead
+				variableDeclarationOut[0] = property.getName() + " : " + property.getType().getQualifiedName();
 
 				// do not generate a getter already there
 				result = true;

--- a/cda/plugins/org.openhealthtools.mdht.uml.cda.transform/src/org/openhealthtools/mdht/uml/cda/transform/TransformCDAPropertyConstraint.java
+++ b/cda/plugins/org.openhealthtools.mdht.uml.cda.transform/src/org/openhealthtools/mdht/uml/cda/transform/TransformCDAPropertyConstraint.java
@@ -318,9 +318,15 @@ public class TransformCDAPropertyConstraint extends TransformPropertyTerminology
 					if (property.getLower() == 1 && property.getUpper() == 1) {
 						body.append(selfName + "->size() = 1");
 					} else {
-						body.append(selfName + "->size() >= " + property.getLower());
+						if (property.getLower() != 0) {
+							// "..->size() >= 0" is an unnecessary tautology, so skip this case
+							body.append(selfName + "->size() >= " + property.getLower());
+						}
 						if (property.getUpper() != LiteralUnlimitedNatural.UNLIMITED) {
-							body.append(" and " + selfName + "->size() <= " + property.getUpper());
+							if (body.length() > 0) {
+								body.append(" and ");
+							}
+							body.append(selfName + "->size() <= " + property.getUpper());
 						}
 					}
 				}

--- a/core/plugins/org.openhealthtools.mdht.uml.transform/src/org/openhealthtools/mdht/uml/transform/ecore/TransformAbstract.java
+++ b/core/plugins/org.openhealthtools.mdht.uml.transform/src/org/openhealthtools/mdht/uml/transform/ecore/TransformAbstract.java
@@ -174,6 +174,24 @@ public abstract class TransformAbstract extends AbstractTransform {
 			hasNullFlavor = isSubTypeOfANY((Class) baseProperty.getType());
 		}
 
+		if (enableVariation_UseOriginalLowerbound()) {
+			if (hasNullFlavor && property.getLower() == 0) {
+				if (baseProperty.upperBound() == 1) {
+					nullFlavorBody = "((not " + selfName + ".oclIsUndefined()) and " + selfName +
+							".isNullFlavorUndefined()) implies (" + body + ")";
+				} else {
+					// must have size()==1 to have nullFlavor
+					nullFlavorBody = "((not " + selfName + "->isEmpty()) and " + selfName +
+							"->exists(element | element.isNullFlavorUndefined()))" + " implies (" + body + ")";
+				}
+			} else if (property.getLower() == 0) {
+				if (baseProperty.upperBound() == 1) {
+					nullFlavorBody = "(not " + selfName + ".oclIsUndefined()) implies (" + body + ")";
+				} else {
+					nullFlavorBody = "(not " + selfName + "->isEmpty()) implies (" + body + ")";
+				}
+			}
+		} else
 		if (hasNullFlavor && !getEcoreProfile().isMandatory(property)) {
 			if (baseProperty.upperBound() == 1) {
 				nullFlavorBody = "(" + selfName + ".oclIsUndefined() or " + selfName +
@@ -351,5 +369,31 @@ public abstract class TransformAbstract extends AbstractTransform {
 			retVal = parentNames.contains("ANY");
 		}
 		return retVal;
+	}
+	
+	/**
+	 * Enable change type 2.
+	 * 
+	 * Even as the original type is not available in the Java runtime for the generated Java code, it is useful to know the original type for
+	 * Schematron purposes,
+	 * as the Schematron generator can generate special type checking xpath for the specialized type.
+	 * 
+	 * @return whether to use the type system of the concrete UML model (<code>true</code>) or the CDA base model (<code>false</code>)
+	 */
+	public boolean enableVariation_UseOriginalType() {
+		return false;
+	}
+
+	/**
+	 * Enable change type 3/4.
+	 * 
+	 * In order to report that a conformance requirement is not met, we need a scenario that fails.
+	 * In order to accomplish this, we imply a lower bound of 1 for all constraints.
+	 * If not we would be checking for size >=0 and size <=1 which would not fail
+	 * 
+	 * @return whether to use the original lower bound value (<code>true</code>) or the implied one (<code>false</code>)
+	 */
+	public boolean enableVariation_UseOriginalLowerbound() {
+		return false;
 	}
 }

--- a/core/plugins/org.openhealthtools.mdht.uml.transform/src/org/openhealthtools/mdht/uml/transform/ecore/TransformAssociation.java
+++ b/core/plugins/org.openhealthtools.mdht.uml.transform/src/org/openhealthtools/mdht/uml/transform/ecore/TransformAssociation.java
@@ -105,10 +105,12 @@ public abstract class TransformAssociation extends TransformAbstract {
 		// Support target class without templateId by using its superclass template.
 		// For untemplated classes (subclasses of CDA), use the base CDA class (last parent).
 		Class constraintTarget = targetClass;
-		List<Classifier> parents = new ArrayList<Classifier>(targetClass.getGenerals());
-		while (!parents.isEmpty() && !getEcoreProfile().isPrimaryEClass(constraintTarget)) {
-			if (parents.get(0) instanceof Class) {
-				constraintTarget = (Class) parents.remove(0);
+		if (!enableVariation_UseOriginalType()) {
+			List<Classifier> parents = new ArrayList<Classifier>(targetClass.getGenerals());
+			while (!parents.isEmpty() && !getEcoreProfile().isPrimaryEClass(constraintTarget)) {
+				if (parents.get(0) instanceof Class) {
+					constraintTarget = (Class) parents.remove(0);
+				}
 			}
 		}
 
@@ -181,13 +183,13 @@ public abstract class TransformAssociation extends TransformAbstract {
 			final boolean isEmpty = (upper == 0);
 			final int lower = isEmpty
 					? 0
-					: Math.max(1, sourceProperty.getLower());
+					: Math.max(enableVariation_UseOriginalLowerbound() ? 0: 1, sourceProperty.getLower());
 
 			// can't use quantifiers like 'one' and 'exists' with a selector because it filters a collection.
 			// Note that 'exists' isn't applicable to lower bounds greater than 1
 			// open - is association open or closed
 			final boolean open = isOpen(association);
-			final boolean one = (((selector == null) || (selector.length() == 0)) && (upper == 1)) && open;
+			final boolean one = (((selector == null) || (selector.length() == 0)) && (upper == 1)) && open && (enableVariation_UseOriginalLowerbound() ? lower == 1 : true);
 			final boolean notEmpty = (lower == 1) && (upper == LiteralUnlimitedNatural.UNLIMITED);
 			final boolean exists = (notEmpty && ((selector == null) || (selector.length() == 0))) && open;
 
@@ -205,7 +207,7 @@ public abstract class TransformAssociation extends TransformAbstract {
 				// don't use %d in case locale introduces a thousands separator
 				// range = String.format("%s..%s", lower, upper);
 				// range = null;
-				comparator = " >= " + lower;
+				comparator = lower == 0 ? null : " >= " + lower;
 				upperComparator = " <= " + upper;
 			} else {
 				// if the upper < lower, then it only makes sense if upper is -1 (*)
@@ -256,6 +258,9 @@ public abstract class TransformAssociation extends TransformAbstract {
 					if (upperComparator == null) {
 						// compare the cardinality against some number
 						constraintBody.append(comparator);
+					} else if (comparator == null) {
+						// compare the cardinality against some number
+						constraintBody.append(upperComparator);
 					} else {
 						String select = constraintBody.toString();
 						constraintBody.append(comparator).append(" and ").append(select).append(upperComparator);
@@ -391,6 +396,10 @@ public abstract class TransformAssociation extends TransformAbstract {
 			constraintTarget.getName(),
 			org.eclipse.uml2.common.util.UML2Util.getValidJavaIdentifier(constraintTarget.getName()));
 
+		if (enableVariation_UseOriginalType()) {
+			return retVal;
+		}
+		
 		String[] arrStr = retVal.split("::");
 		if (arrStr.length > 2) {
 			retVal = getBaseClass(constraintTarget).getQualifiedName();


### PR DESCRIPTION
generator; however, they are inactive in the original (for the Java runtime) unless activated by overriding the
enableVariation_*() methods (for schematron purposes). They incorporate change 1/2/3/4.

Change type 5 was already solved, no action been done here.

Change type 6 was a bug printing a false type string, see
https://nehta.webel.com.au/node/632
and is fixed now.

Also,  "->size()>=0 " expressions are optimized away.

This pull request does not bring new functional changes, it just makes the previous complete copy of the OCL generator within the Schematron project superfluous (instead the enableVariation_*()  can be overridden to activate the schematron adjustment). 

Tests done: Passes nehta's regression environment.

Also, it was tested for eReferral, that the xpaths don't change and that the schematron test expressions didn't change semantically (but syntactically, e.g. using size()=1 instead of one()).
